### PR TITLE
Add docker-compose health checker  …

### DIFF
--- a/shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml
@@ -109,8 +109,18 @@ services:
         condition: service_healthy
     ports:
       - 9195:9195
+    healthcheck:
+      test: [ "CMD", "wget", "http://shenyu-integrated-test-http:9195/http/test/path/123?name=Tom" ]
+      timeout: 2s
+      retries: 30
     networks:
       - shenyu
+  health-checker:
+    container_name: health-checker
+    image: hello-world
+    depends_on:
+      shenyu-integrated-test-http:
+        condition: service_healthy
 
 networks:
   shenyu:


### PR DESCRIPTION
To make sure that gateway start up completely before running integrated tests

This is used to resolved the problem that integrated tests are not stable

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/projects/shenyu/contributor/).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
