### PR TITLE
Update integrated CI to make sure docker compose start up all containers

### DIFF
--- a/.github/workflows/integrated-test-http.yml
+++ b/.github/workflows/integrated-test-http.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
 #        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        os: [ ubuntu-latest ]
+        os: [ macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Support longpaths
@@ -62,7 +62,7 @@ jobs:
         run: ./mvnw -B clean install -DskipTests -f ./shenyu-integrated-test/shenyu-integrated-test-http/pom.xml
       - name: Start docker compose
         if: env.SKIP_CI != 'true'
-        run: docker-compose -f ./shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml up -d
+        run: docker compose -f ./shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml up -d
       - name: Run test
         if: env.SKIP_CI != 'true'
         run: ./mvnw test -f ./shenyu-integrated-test/shenyu-integrated-test-http/pom.xml


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo

According to my understanding, on Ubutun, the `docker compose up -d` only create all containers but do not started up completely. But on MacOS `docker compose up -d` will start up containers.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor/).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
