### PR TITLE
Update integrated CI to make sure docker compose start up all containers

### DIFF
--- a/.github/workflows/integrated-test-http.yml
+++ b/.github/workflows/integrated-test-http.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Start docker compose
         if: env.SKIP_CI != 'true'
         run: docker-compose -f ./shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml up -d
+      - name: Wait for docker compose start up completely
+        if: env.SKIP_CI != 'true'
+        run: while ! docker ps -a | grep health-checker | grep "Exited (0)"; do sleep 2; done; echo "start up completely"
       - name: Run test
         if: env.SKIP_CI != 'true'
         run: ./mvnw test -f ./shenyu-integrated-test/shenyu-integrated-test-http/pom.xml


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo

Using while loop to wait and check if docker compose start up all containers.

On Ubuntu, the `docker compose up -d` only create all containers but do not start them up. So sometimes the integrated tests failed.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor/).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
