### PR TITLE
[ISSUE #1717]Fix bug(#1717), when sync data by zookeeper, it will throw ClassCastException

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataService.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataService.java
@@ -19,11 +19,6 @@ package org.apache.shenyu.sync.data.zookeeper;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.I0Itec.zkclient.IZkDataListener;
 import org.I0Itec.zkclient.ZkClient;
@@ -40,6 +35,12 @@ import org.apache.shenyu.sync.data.api.AuthDataSubscriber;
 import org.apache.shenyu.sync.data.api.MetaDataSubscriber;
 import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
 import org.apache.shenyu.sync.data.api.SyncDataService;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * this cache data with zookeeper.
@@ -236,7 +237,7 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
             @Override
             public void handleDataChange(final String dataPath, final Object data) {
                 Optional.ofNullable(data)
-                        .ifPresent(d -> Optional.ofNullable(pluginDataSubscriber).ifPresent(e -> e.onSubscribe((PluginData) d)));
+                        .ifPresent(d -> Optional.ofNullable(pluginDataSubscriber).ifPresent(e -> e.onSubscribe(GsonUtils.getInstance().fromJson(data.toString(), PluginData.class))));
             }
 
             @Override
@@ -252,7 +253,7 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         zkClient.subscribeDataChanges(path, new IZkDataListener() {
             @Override
             public void handleDataChange(final String dataPath, final Object data) {
-                cacheSelectorData((SelectorData) data);
+                cacheSelectorData(GsonUtils.getInstance().fromJson(data.toString(), SelectorData.class));
             }
 
             @Override
@@ -266,7 +267,7 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         zkClient.subscribeDataChanges(path, new IZkDataListener() {
             @Override
             public void handleDataChange(final String dataPath, final Object data) {
-                cacheRuleData((RuleData) data);
+                cacheRuleData(GsonUtils.getInstance().fromJson(data.toString(), RuleData.class));
             }
 
             @Override
@@ -280,7 +281,7 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         zkClient.subscribeDataChanges(realPath, new IZkDataListener() {
             @Override
             public void handleDataChange(final String dataPath, final Object data) {
-                cacheAuthData((AppAuthData) data);
+                cacheAuthData(GsonUtils.getInstance().fromJson(data.toString(), AppAuthData.class));
             }
 
             @Override
@@ -294,7 +295,7 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         zkClient.subscribeDataChanges(realPath, new IZkDataListener() {
             @Override
             public void handleDataChange(final String dataPath, final Object data) {
-                cacheMetaData((MetaData) data);
+                cacheMetaData(GsonUtils.getInstance().fromJson(data.toString(), MetaData.class));
             }
 
             @SneakyThrows

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/test/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/test/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java
@@ -139,7 +139,7 @@ public final class ZookeeperSyncDataServiceTest {
         }, Collections.emptyList(), Collections.emptyList());
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_PLUGIN_PATH), captor.capture());
-        captor.getValue().handleDataChange(MOCK_PLUGIN_PATH, changedPluginData);
+        captor.getValue().handleDataChange(MOCK_PLUGIN_PATH, GsonUtils.getInstance().toJson(changedPluginData));
         assertThat(subscribeList.size(), is(2));
         assertTrue(subscribeList.get(1).getEnabled());
     }
@@ -185,7 +185,7 @@ public final class ZookeeperSyncDataServiceTest {
         }, Collections.emptyList(), Collections.emptyList());
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_SELECTOR_PATH), captor.capture());
-        captor.getValue().handleDataChange(MOCK_SELECTOR_PATH, changedSelectorData);
+        captor.getValue().handleDataChange(MOCK_SELECTOR_PATH, GsonUtils.getInstance().toJson(changedSelectorData));
         assertThat(subscribeList.size(), is(2));
         assertTrue(subscribeList.get(1).getEnabled());
     }
@@ -231,7 +231,7 @@ public final class ZookeeperSyncDataServiceTest {
         }, Collections.emptyList(), Collections.emptyList());
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_RULE_PATH), captor.capture());
-        captor.getValue().handleDataChange(MOCK_RULE_PATH, changedRuleData);
+        captor.getValue().handleDataChange(MOCK_RULE_PATH, GsonUtils.getInstance().toJson(changedRuleData));
         assertThat(subscribeList.size(), is(2));
         Assert.assertTrue(subscribeList.get(1).getEnabled());
     }
@@ -288,7 +288,7 @@ public final class ZookeeperSyncDataServiceTest {
                 null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_APP_AUTH_PATH), captor.capture());
-        captor.getValue().handleDataChange(MOCK_APP_AUTH_PATH, changedAppAuthData);
+        captor.getValue().handleDataChange(MOCK_APP_AUTH_PATH, GsonUtils.getInstance().toJson(changedAppAuthData));
         assertThat(subscribeList.size(), is(2));
         assertTrue(subscribeList.get(1).getEnabled());
     }
@@ -352,7 +352,7 @@ public final class ZookeeperSyncDataServiceTest {
         Assert.assertEquals(1, subscribeList.size());
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_META_DATA_PATH), captor.capture());
-        captor.getValue().handleDataChange(MOCK_META_DATA_PATH, changedMetaData);
+        captor.getValue().handleDataChange(MOCK_META_DATA_PATH, GsonUtils.getInstance().toJson(changedMetaData));
         assertThat(subscribeList.size(), is(2));
         assertTrue(subscribeList.get(1).getEnabled());
     }


### PR DESCRIPTION
Fix bug(#1717), when sync data by zookeeper, it will throw ClassCastException.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor/).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
