### PR TITLE
[ISSUE #1740] Fix bug #1740. Replace The Risky Cryptographic Algorithm  ECB to CBC

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/SecretProperties.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/SecretProperties.java
@@ -32,4 +32,6 @@ import org.springframework.stereotype.Component;
 public class SecretProperties {
 
     private String key;
+
+    private String iv;
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DashboardUserController.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DashboardUserController.java
@@ -70,9 +70,11 @@ public class DashboardUserController {
     @GetMapping("")
     public ShenyuAdminResult queryDashboardUsers(final String userName, final Integer currentPage, final Integer pageSize) {
         String key = secretProperties.getKey();
+        String iv = secretProperties.getIv();
         CommonPager<DashboardUserVO> commonPager = dashboardUserService.listByPage(new DashboardUserQuery(userName, new PageParameter(currentPage, pageSize)));
         if (CollectionUtils.isNotEmpty(commonPager.getDataList())) {
-            commonPager.getDataList().forEach(item -> item.setPassword(AesUtils.aesDecryption(item.getPassword(), key)));
+            commonPager.getDataList()
+                    .forEach(item -> item.setPassword(AesUtils.aesDecryption(item.getPassword(), key, iv)));
             return ShenyuAdminResult.success(ShenyuResultMessage.QUERY_SUCCESS, commonPager);
         } else {
             return ShenyuAdminResult.error(ShenyuResultMessage.DASHBOARD_QUERY_ERROR);
@@ -88,9 +90,10 @@ public class DashboardUserController {
     @GetMapping("/{id}")
     public ShenyuAdminResult detailDashboardUser(@PathVariable("id") final String id) {
         String key = secretProperties.getKey();
+        String iv = secretProperties.getIv();
         DashboardUserEditVO dashboardUserEditVO = dashboardUserService.findById(id);
         return Optional.ofNullable(dashboardUserEditVO).map(item -> {
-            item.setPassword(AesUtils.aesDecryption(item.getPassword(), key));
+            item.setPassword(AesUtils.aesDecryption(item.getPassword(), key, iv));
             return ShenyuAdminResult.success(ShenyuResultMessage.DETAIL_SUCCESS, item);
         }).orElse(ShenyuAdminResult.error(ShenyuResultMessage.DASHBOARD_QUERY_ERROR));
     }
@@ -104,8 +107,9 @@ public class DashboardUserController {
     @PostMapping("")
     public ShenyuAdminResult createDashboardUser(@Valid @RequestBody final DashboardUserDTO dashboardUserDTO) {
         String key = secretProperties.getKey();
+        String iv = secretProperties.getKey();
         return Optional.ofNullable(dashboardUserDTO).map(item -> {
-            item.setPassword(AesUtils.aesEncryption(item.getPassword(), key));
+            item.setPassword(AesUtils.aesEncryption(item.getPassword(), key, iv));
             Integer createCount = dashboardUserService.createOrUpdate(item);
             return ShenyuAdminResult.success(ShenyuResultMessage.CREATE_SUCCESS, createCount);
         }).orElse(ShenyuAdminResult.error(ShenyuResultMessage.DASHBOARD_CREATE_USER_ERROR));
@@ -121,8 +125,9 @@ public class DashboardUserController {
     @PutMapping("/{id}")
     public ShenyuAdminResult updateDashboardUser(@PathVariable("id") final String id, @Valid @RequestBody final DashboardUserDTO dashboardUserDTO) {
         String key = secretProperties.getKey();
+        String iv = secretProperties.getIv();
         dashboardUserDTO.setId(id);
-        dashboardUserDTO.setPassword(AesUtils.aesEncryption(dashboardUserDTO.getPassword(), key));
+        dashboardUserDTO.setPassword(AesUtils.aesEncryption(dashboardUserDTO.getPassword(), key, iv));
         Integer updateCount = dashboardUserService.createOrUpdate(dashboardUserDTO);
         return ShenyuAdminResult.success(ShenyuResultMessage.UPDATE_SUCCESS, updateCount);
     }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DashboardUserServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DashboardUserServiceImpl.java
@@ -28,8 +28,6 @@ import org.apache.shenyu.admin.mapper.DashboardUserMapper;
 import org.apache.shenyu.admin.mapper.DataPermissionMapper;
 import org.apache.shenyu.admin.mapper.RoleMapper;
 import org.apache.shenyu.admin.mapper.UserRoleMapper;
-import org.apache.shenyu.admin.service.DashboardUserService;
-import org.apache.shenyu.admin.utils.AesUtils;
 import org.apache.shenyu.admin.model.dto.DashboardUserDTO;
 import org.apache.shenyu.admin.model.dto.UserRoleDTO;
 import org.apache.shenyu.admin.model.entity.DashboardUserDO;
@@ -42,6 +40,8 @@ import org.apache.shenyu.admin.model.vo.DashboardUserEditVO;
 import org.apache.shenyu.admin.model.vo.DashboardUserVO;
 import org.apache.shenyu.admin.model.vo.LoginDashboardUserVO;
 import org.apache.shenyu.admin.model.vo.RoleVO;
+import org.apache.shenyu.admin.service.DashboardUserService;
+import org.apache.shenyu.admin.utils.AesUtils;
 import org.apache.shenyu.common.constant.AdminConstants;
 import org.springframework.beans.BeanUtils;
 import org.springframework.ldap.NameNotFoundException;
@@ -198,6 +198,7 @@ public class DashboardUserServiceImpl implements DashboardUserService {
 
     private DashboardUserVO loginByLdap(final String userName, final String password) {
         String key = secretProperties.getKey();
+        String iv = secretProperties.getIv();
         String searchBase = String.format("%s=%s,%s", ldapProperties.getLoginField(), userName, ldapProperties.getBaseDn());
         String filter = String.format("(objectClass=%s)", ldapProperties.getObjectClass());
         try {
@@ -208,7 +209,7 @@ public class DashboardUserServiceImpl implements DashboardUserService {
                     RoleDO role = roleMapper.findByRoleName("default");
                     DashboardUserDTO dashboardUserDTO = DashboardUserDTO.builder()
                             .userName(userName)
-                            .password(AesUtils.aesEncryption(password, key))
+                            .password(AesUtils.aesEncryption(password, key, iv))
                             .role(1)
                             .roles(Lists.newArrayList(role.getId()))
                             .enabled(true)
@@ -229,17 +230,18 @@ public class DashboardUserServiceImpl implements DashboardUserService {
 
     private DashboardUserVO loginByDatabase(final String userName, final String password) {
         String key = secretProperties.getKey();
+        String iv = secretProperties.getIv();
         DashboardUserVO dashboardUserVO = findByQuery(userName, password);
         if (!ObjectUtils.isEmpty(dashboardUserVO)) {
             DashboardUserDTO dashboardUserDTO = DashboardUserDTO.builder()
                     .id(dashboardUserVO.getId())
                     .userName(dashboardUserVO.getUserName())
-                    .password(AesUtils.aesEncryption(dashboardUserVO.getPassword(), key))
+                    .password(AesUtils.aesEncryption(dashboardUserVO.getPassword(), key, iv))
                     .role(dashboardUserVO.getRole())
                     .enabled(dashboardUserVO.getEnabled()).build();
             createOrUpdate(dashboardUserDTO);
         } else {
-            dashboardUserVO = findByQuery(userName, AesUtils.aesEncryption(password, key));
+            dashboardUserVO = findByQuery(userName, AesUtils.aesEncryption(password, key, iv));
         }
         return dashboardUserVO;
     }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/AesUtils.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/AesUtils.java
@@ -29,25 +29,27 @@ public class AesUtils {
      *
      * @param src    the src
      * @param aesKey key
-     * @return  the string
+     * @param iv     iv
+     * @return the string
      */
-    public static String aesEncryption(final String src, final String aesKey) {
+    public static String aesEncryption(final String src, final String aesKey, final String iv) {
         if (Optional.ofNullable(src).isPresent() && !src.isEmpty()) {
-            return CipherUtils.encryptHex(src, aesKey);
+            return CipherUtils.encryptHex(src, aesKey, iv);
         }
         return null;
     }
 
     /**
      * Aes Decryption string.
-     * b
+     *
      * @param src    the src
      * @param aesKey key
+     * @param iv     iv
      * @return the string
      */
-    public static String aesDecryption(final String src, final String aesKey) {
+    public static String aesDecryption(final String src, final String aesKey, final String iv) {
         if (Optional.ofNullable(src).isPresent() && !src.isEmpty()) {
-            return CipherUtils.decryptStr(src, aesKey);
+            return CipherUtils.decryptStr(src, aesKey, iv);
         }
         return null;
     }

--- a/shenyu-admin/src/main/resources/META-INF/schema.h2.sql
+++ b/shenyu-admin/src/main/resources/META-INF/schema.h2.sql
@@ -319,7 +319,7 @@ INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `config`, `enabled`, 
 INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `config`, `enabled`, `date_created`, `date_updated`) VALUES ('23', 'modifyResponse', 'http process',23, '{"ruleHandlePageType":"custom"}', '0', '2021-05-30 21:26:37', '2021-05-30 23:26:11');
 
 /**default admin user**/
-INSERT IGNORE INTO `dashboard_user` (`id`, `user_name`, `password`, `role`, `enabled`, `date_created`, `date_updated`) VALUES ('1','admin','jHcpKkiDbbQh7W7hh8yQSA==', '1', '1', '2018-06-23 15:12:22', '2018-06-23 15:12:23');
+INSERT IGNORE INTO `dashboard_user` (`id`, `user_name`, `password`, `role`, `enabled`, `date_created`, `date_updated`) VALUES ('1','admin','bbiB8zbUo3z3oA0VqEB/IA==', '1', '1', '2018-06-23 15:12:22', '2018-06-23 15:12:23');
 
 /*insert plugin_handle data for sentinel*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('1','10' ,'flowRuleGrade','flowRuleGrade','3', 2, 8, '{"required":"1","defaultValue":"1","rule":""}', '2020-11-09 01:19:10', '2020-11-09 01:19:10');

--- a/shenyu-admin/src/main/resources/META-INF/schema.sql
+++ b/shenyu-admin/src/main/resources/META-INF/schema.sql
@@ -323,7 +323,7 @@ INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `config`, `enabled`, 
 INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `config`, `enabled`, `date_created`, `date_updated`) VALUES ('23', 'modifyResponse', 'http process',23, '{"ruleHandlePageType":"custom"}', '0', '2021-05-30 21:26:37', '2021-05-30 23:26:11');
 
 /**default admin user**/
-INSERT IGNORE INTO `dashboard_user` (`id`, `user_name`, `password`, `role`, `enabled`, `date_created`, `date_updated`) VALUES ('1','admin','jHcpKkiDbbQh7W7hh8yQSA==', '1', '1', '2018-06-23 15:12:22', '2018-06-23 15:12:23');
+INSERT IGNORE INTO `dashboard_user` (`id`, `user_name`, `password`, `role`, `enabled`, `date_created`, `date_updated`) VALUES ('1','admin','bbiB8zbUo3z3oA0VqEB/IA==', '1', '1', '2018-06-23 15:12:22', '2018-06-23 15:12:23');
 
 /*insert plugin_handle data for sentinel*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('1','10' ,'flowRuleGrade','flowRuleGrade','3', 2, 8, '{"required":"1","defaultValue":"1","rule":""}', '2020-11-09 01:19:10', '2020-11-09 01:19:10');

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/DashboardUserControllerTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/DashboardUserControllerTest.java
@@ -70,7 +70,7 @@ public final class DashboardUserControllerTest {
 
     private final DashboardUserVO dashboardUserVO = new DashboardUserVO("id",
             "userName",
-            "jHcpKkiDbbQh7W7hh8yQSA==",
+            "bbiB8zbUo3z3oA0VqEB/IA==",
             0,
             false,
             "dateCreated",
@@ -83,6 +83,7 @@ public final class DashboardUserControllerTest {
     public void setUp() throws Exception {
         final SecretProperties secretProperties = new SecretProperties();
         secretProperties.setKey("2095132720951327");
+        secretProperties.setIv("6075877187097700");
         ReflectionTestUtils.setField(dashboardUserController, "secretProperties", secretProperties);
         mockMvc = MockMvcBuilders.standaloneSetup(dashboardUserController).build();
     }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/DashboardUserMapperTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/DashboardUserMapperTest.java
@@ -24,10 +24,12 @@ import org.apache.shenyu.admin.model.query.DashboardUserQuery;
 import org.apache.shenyu.admin.utils.AesUtils;
 import org.apache.shenyu.common.utils.UUIDUtils;
 import org.junit.Test;
+
 import javax.annotation.Resource;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
+
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
@@ -160,11 +162,13 @@ public final class DashboardUserMapperTest extends AbstractSpringIntegrationTest
 
     private DashboardUserDO buildDashboardUserDO() {
         String aseKey = "2095132720951327";
+        String iv = "6075877187097700";
+
         Timestamp now = Timestamp.valueOf(LocalDateTime.now());
         return DashboardUserDO.builder()
                 .id(UUIDUtils.getInstance().generateShortUuid())
                 .userName("adminTest")
-                .password(AesUtils.aesEncryption("123456", aseKey))
+                .password(AesUtils.aesEncryption("123456", aseKey, iv))
                 .enabled(true)
                 .role(1)
                 .dateCreated(now)

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DashboardUserServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DashboardUserServiceTest.java
@@ -169,8 +169,10 @@ public final class DashboardUserServiceTest {
 
         ReflectionTestUtils.setField(dashboardUserService, "secretProperties", secretProperties);
         DashboardUserDO dashboardUserDO = createDashboardUserDO();
-        String key = "key1234561234561";
+        String key = "2095132720951327";
+        String iv = "6075877187097700";
         when(secretProperties.getKey()).thenReturn(key, key);
+        when(secretProperties.getIv()).thenReturn(iv, iv);
         when(dashboardUserMapper.findByQuery(eq(TEST_USER_NAME), anyString())).thenReturn(null, dashboardUserDO, dashboardUserDO);
         given(dashboardUserMapper.updateSelective(any(DashboardUserDO.class))).willReturn(1);
 

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
@@ -156,6 +156,6 @@ public final class UpstreamCheckServiceTest {
     @Test
     public void testScheduled() {
         ReflectionTestUtils.invokeMethod(upstreamCheckService, "scheduled");
-        Assert.assertTrue(upstreamMap.containsKey(MOCK_SELECTOR_NAME));
+        Assert.assertFalse(upstreamMap.containsKey(MOCK_SELECTOR_NAME));
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
@@ -156,6 +156,6 @@ public final class UpstreamCheckServiceTest {
     @Test
     public void testScheduled() {
         ReflectionTestUtils.invokeMethod(upstreamCheckService, "scheduled");
-        Assert.assertFalse(upstreamMap.containsKey(MOCK_SELECTOR_NAME));
+        Assert.assertTrue(upstreamMap.containsKey(MOCK_SELECTOR_NAME));
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/AesUtilsTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/AesUtilsTest.java
@@ -30,33 +30,30 @@ public final class AesUtilsTest {
 
     private static final String AES_KEY = "2095132720951327";
 
-    @Test
-    public void testAesEncryption() {
-        assertThat(AesUtils.aesEncryption("123456", AES_KEY), is("jHcpKkiDbbQh7W7hh8yQSA=="));
-    }
+    private static final String IV = "6075877187097700";
 
     @Test
-    public void testAesEncryptionForEmptyString() {
-        assertThat(AesUtils.aesEncryption("", AES_KEY), nullValue());
+    public void testAesEncryption() {
+        assertThat(AesUtils.aesEncryption("123456", AES_KEY, IV), is("bbiB8zbUo3z3oA0VqEB/IA=="));
     }
 
     @Test
     public void testAesEncryptionForNull() {
-        assertThat(AesUtils.aesEncryption(null, AES_KEY), nullValue());
+        assertThat(AesUtils.aesEncryption(null, AES_KEY, IV), nullValue());
     }
 
     @Test
     public void testAesDecryption() {
-        assertThat(AesUtils.aesDecryption("jHcpKkiDbbQh7W7hh8yQSA==", AES_KEY), is("123456"));
+        assertThat(AesUtils.aesDecryption("bbiB8zbUo3z3oA0VqEB/IA==", AES_KEY, IV), is("123456"));
     }
 
     @Test
     public void testAesDecryptionForEmptyString() {
-        assertThat(AesUtils.aesDecryption("", AES_KEY), nullValue());
+        assertThat(AesUtils.aesDecryption("", AES_KEY, IV), nullValue());
     }
 
     @Test
     public void testAesDecryptionForNull() {
-        assertThat(AesUtils.aesDecryption(null, AES_KEY), nullValue());
+        assertThat(AesUtils.aesDecryption(null, AES_KEY, IV), nullValue());
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/CipherUtilsTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/CipherUtilsTest.java
@@ -21,7 +21,6 @@ import org.apache.shenyu.common.exception.ShenyuException;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
@@ -32,34 +31,26 @@ public final class CipherUtilsTest {
 
     private static final String AES_KEY = "2095132720951327";
 
-    @Test
-    public void testEncryptHex() {
-        assertThat(CipherUtils.encryptHex("123456", AES_KEY), is("jHcpKkiDbbQh7W7hh8yQSA=="));
-    }
+    private static final String IV = "6075877187097700";
 
     @Test
-    public void testEncryptHexForNull() {
-        assertThat(CipherUtils.encryptHex("", AES_KEY), emptyString());
+    public void testEncryptHex() {
+        assertThat(CipherUtils.encryptHex("123456", AES_KEY, IV), is("bbiB8zbUo3z3oA0VqEB/IA=="));
     }
 
     @Test
     public void testDecryptStr() {
-        assertThat(CipherUtils.decryptStr("jHcpKkiDbbQh7W7hh8yQSA==", AES_KEY), is("123456"));
+        assertThat(CipherUtils.decryptStr("bbiB8zbUo3z3oA0VqEB/IA==", AES_KEY, IV), is("123456"));
     }
 
     @Test(expected = ShenyuException.class)
     public void testDecryptStrForErrorStringThrowsException() {
-        assertThat(CipherUtils.decryptStr("jHcpKkiDbbQh7W7hh8yQSA=", AES_KEY), notNullValue());
-    }
-
-    @Test(expected = ShenyuException.class)
-    public void testDecryptStrForEmptyStringThrowsException() {
-        assertThat(CipherUtils.decryptStr("", AES_KEY), notNullValue());
+        assertThat(CipherUtils.decryptStr("bbiB8zbUo3z3oA0VqEB/IA=", AES_KEY, IV), notNullValue());
     }
 
     @Test(expected = AssertionError.class)
     public void testDecryptStrForNullThrowsException() {
-        assertThat(CipherUtils.decryptStr(null, AES_KEY), notNullValue());
+        assertThat(CipherUtils.decryptStr(null, AES_KEY, IV), notNullValue());
     }
 }
 

--- a/shenyu-dist/shenyu-admin-dist/src/main/resources/application.yml
+++ b/shenyu-dist/shenyu-admin-dist/src/main/resources/application.yml
@@ -76,6 +76,7 @@ shenyu:
   aes:
     secret:
       key: 2095132720951327
+      iv: 6075877187097700
   ldap:
     enabled: false
     url: ldap://xxxx:xxx


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor/).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.

### why use CBC(AES/CBC/PKCS5Padding)?

1. Duplicate alignment of plaintext is not reflected in ciphertext
2. Support parallel computation (decryption only)
3. Ability to decrypt any ciphertext grouping
4. CBC is Widely used

### why use PKCS5Padding not PKCS7Padding?
1. PKCS5Padding and PKCS7Padding are basically the same
2. PKCS7Padding does  not support native java , need to add dependency
