### PR TITLE
[ISSUE #1770] Solve the problem of duplicate URL-encoding

### DIFF
--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
@@ -76,9 +76,9 @@ public class WebClientPlugin implements ShenyuPlugin {
         int retryTimes = (int) Optional.ofNullable(exchange.getAttribute(Constants.HTTP_RETRY)).orElse(0);
         log.info("The request urlPath is {}, retryTimes is {}", urlPath, retryTimes);
         HttpMethod method = HttpMethod.valueOf(exchange.getRequest().getMethodValue());
-        try{
+        try {
             uriObject = new URI(urlPath);
-        }catch (Exception e){
+        } catch (Exception e) {
             log.error("build URI object error",e);
             return WebFluxResultUtils.result(exchange, e);
         }

--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
@@ -75,8 +75,7 @@ public class WebClientPlugin implements ShenyuPlugin {
         int retryTimes = (int) Optional.ofNullable(exchange.getAttribute(Constants.HTTP_RETRY)).orElse(0);
         log.info("The request urlPath is {}, retryTimes is {}", urlPath, retryTimes);
         HttpMethod method = HttpMethod.valueOf(exchange.getRequest().getMethodValue());
-        URI uriObject = URI.create(urlPath);
-        WebClient.RequestBodySpec requestBodySpec = webClient.method(method).uri(uriObject);
+        WebClient.RequestBodySpec requestBodySpec = webClient.method(method).uri(URI.create(urlPath));
         return handleRequestBody(requestBodySpec, exchange, timeout, retryTimes, chain);
     }
 

--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
@@ -65,7 +65,6 @@ public class WebClientPlugin implements ShenyuPlugin {
     @Override
     public Mono<Void> execute(final ServerWebExchange exchange, final ShenyuPluginChain chain) {
         final ShenyuContext shenyuContext = exchange.getAttribute(Constants.CONTEXT);
-        URI uriObject;
         assert shenyuContext != null;
         String urlPath = exchange.getAttribute(Constants.HTTP_URL);
         if (StringUtils.isEmpty(urlPath)) {
@@ -76,12 +75,7 @@ public class WebClientPlugin implements ShenyuPlugin {
         int retryTimes = (int) Optional.ofNullable(exchange.getAttribute(Constants.HTTP_RETRY)).orElse(0);
         log.info("The request urlPath is {}, retryTimes is {}", urlPath, retryTimes);
         HttpMethod method = HttpMethod.valueOf(exchange.getRequest().getMethodValue());
-        try {
-            uriObject = new URI(urlPath);
-        } catch (Exception e) {
-            log.error("build URI object error",e);
-            return WebFluxResultUtils.result(exchange, e);
-        }
+        URI uriObject = URI.create(urlPath);
         WebClient.RequestBodySpec requestBodySpec = webClient.method(method).uri(uriObject);
         return handleRequestBody(requestBodySpec, exchange, timeout, retryTimes, chain);
     }


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo
fix #1770 
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
The webclient will encode the incoming string type parameters, which will cause an error, we need to use the URI object.

Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor/).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
