### PR TITLE
Fix BUG: Cannot startup shenyu-admin docker on Windows

### DIFF
--- a/shenyu-dist/shenyu-admin-dist/entrypoint.sh
+++ b/shenyu-dist/shenyu-admin-dist/entrypoint.sh
@@ -18,4 +18,7 @@
 
 [[ -d ./conf-ext ]] && cp -f ./conf-ext/* ./conf
 
+mkdir -p ${LOCAL_PATH}/logs
+touch ${LOCAL_PATH}/logs/shenyu-admin.log
+
 /bin/sh ${LOCAL_PATH}/bin/start.sh && tail -f ${LOCAL_PATH}/logs/shenyu-admin.log


### PR DESCRIPTION
When I try to setup integrated test environment on Windows, I got error:

```
shenyu-admin exited with code 1
shenyu-admin                 | Please check the log files: /opt/shenyu-admin/logs
': No such file or directory | tail: can't open '/opt/shenyu-admin/logs/shenyu-admin.log
shenyu-admin                 | tail: no files
```
But actually shenyu-admin has already created this file. The root cause is that, when we try to run `tail -f`, it can not read the file which was not created even shenyu-admin created it later.

So we must create the file and update the file mod to make sure it works as expected on Windows platform, specially on Docker based on Windows WSL.


// Describe your PR here; eg. Fixes #issueNo

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor/).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
