### PR TITLE
update UpstreamCheckService

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java
@@ -69,13 +69,13 @@ public class UpstreamCheckService {
 
     private static final Set<ZombieUpstream> ZOMBIE_SET = Sets.newConcurrentHashSet();
 
-    private int zombieCheckTimes;
+    private final int zombieCheckTimes;
 
-    private int scheduledTime;
+    private final int scheduledTime;
 
-    private String registerType;
+    private final String registerType;
 
-    private boolean checked;
+    private final boolean checked;
 
     private final SelectorMapper selectorMapper;
 

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/ZombieUpstream.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/ZombieUpstream.java
@@ -19,6 +19,7 @@ package org.apache.shenyu.common.dto.convert;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -33,21 +34,25 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString
 @Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class ZombieUpstream {
 
     /**
      * divide upstream.
      */
+    @EqualsAndHashCode.Include
     private DivideUpstream divideUpstream;
 
     /**
      * total check times.
      */
+    @EqualsAndHashCode.Include
     private int zombieCheckTimes;
 
     /**
      * origin selector name.
      */
+    @EqualsAndHashCode.Include
     private String selectorName;
 
     /**


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo
* UpstreamCheckService use ZombieUpstream in Set structure, but it not override equals and hashCode method explicitly, it may cause error in some scenario
* The fields `zombieCheckTimes`, `scheduledTime`, `registerType`, `checked` are only assigned value in constructor of UpstreamCheckService, these fields's field descriptor can be formatted with `final`
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor/).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
