### PR TITLE
Fix flaky test UpstreamCheckServiceTest#testScheduled

### DIFF
--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
@@ -94,9 +94,6 @@ public final class UpstreamCheckServiceTest {
     @Before
     public void setUp() {
         shenyuRegisterCenterConfig.setRegisterType("http");
-        Properties properties = new Properties();
-        properties.setProperty(Constants.IS_CHECKED, "true");
-        shenyuRegisterCenterConfig.setProps(properties);
 
         // get static variable reference by reflection
         upstreamMap = (Map<String, List<DivideUpstream>>) ReflectionTestUtils.getField(UpstreamCheckService.class, "UPSTREAM_MAP");
@@ -213,6 +210,10 @@ public final class UpstreamCheckServiceTest {
 
     @Test
     public void testClose() {
+        Properties properties = new Properties();
+        properties.setProperty(Constants.IS_CHECKED, "true");
+        shenyuRegisterCenterConfig.setProps(properties);
+        upstreamCheckService = new UpstreamCheckService(selectorMapper, eventPublisher, pluginMapper, selectorConditionMapper, shenyuRegisterCenterConfig);
         ScheduledThreadPoolExecutor executor = Whitebox.getInternalState(upstreamCheckService, "executor");
         assertNotNull(executor);
         upstreamCheckService.close();


### PR DESCRIPTION
##Motivation
- Fix flaky test UpstreamCheckServiceTest#testScheduled

## StackTrace
![image](https://user-images.githubusercontent.com/6297296/128708252-e8524c06-3c98-477e-a8ac-ec6264387e9e.png)

## Root Cause
UpstreamCheckServiceTest will setup below config:
```
Properties properties = new Properties();
properties.setProperty(Constants.IS_CHECKED, "true");
shenyuRegisterCenterConfig.setProps(properties);
```
UpstreamCheckServiceTest will init UpstreamCheckService and invoke UpstreamCheckService#scheduled with fix delay.
UpstreamCheckServiceTest#testScheduled will invoke method `scheduled` manually which may be potential simultaneous with fix delay. this means:
```
zombieSet.clear();    // called by test thread.
setupZombieSet();     //  after here,  zombieSet is 2
upstreamMap.clear(); 
setupUpstreamMap();   // this will fill upstreamMap with 2 DivideUpstream objects. If `executor fix delay` called method `scheduled` before assert, zombieSet is 3. 
```
So the easy way to fix this flaky test will be removed the above config and put it in the method 'testClose' which need it.