### PR TITLE
refactor : replace orElse with orElseGet to avoid calling too many times

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DashboardUserController.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DashboardUserController.java
@@ -95,7 +95,7 @@ public class DashboardUserController {
         return Optional.ofNullable(dashboardUserEditVO).map(item -> {
             item.setPassword(AesUtils.aesDecryption(item.getPassword(), key, iv));
             return ShenyuAdminResult.success(ShenyuResultMessage.DETAIL_SUCCESS, item);
-        }).orElse(ShenyuAdminResult.error(ShenyuResultMessage.DASHBOARD_QUERY_ERROR));
+        }).orElseGet(() -> ShenyuAdminResult.error(ShenyuResultMessage.DASHBOARD_QUERY_ERROR));
     }
 
     /**
@@ -112,7 +112,7 @@ public class DashboardUserController {
             item.setPassword(AesUtils.aesEncryption(item.getPassword(), key, iv));
             Integer createCount = dashboardUserService.createOrUpdate(item);
             return ShenyuAdminResult.success(ShenyuResultMessage.CREATE_SUCCESS, createCount);
-        }).orElse(ShenyuAdminResult.error(ShenyuResultMessage.DASHBOARD_CREATE_USER_ERROR));
+        }).orElseGet(() -> ShenyuAdminResult.error(ShenyuResultMessage.DASHBOARD_CREATE_USER_ERROR));
     }
 
     /**

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DataPermissionController.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DataPermissionController.java
@@ -103,7 +103,7 @@ public class DataPermissionController {
     public ShenyuAdminResult saveSelector(@RequestBody final DataPermissionDTO dataPermissionDTO) {
         return Optional.ofNullable(dataPermissionDTO)
                 .map(item -> ShenyuAdminResult.success(ShenyuResultMessage.SAVE_SUCCESS, dataPermissionService.createSelector(dataPermissionDTO)))
-                .orElse(ShenyuAdminResult.error(ShenyuResultMessage.SAVE_FAILED));
+                .orElseGet(() -> ShenyuAdminResult.error(ShenyuResultMessage.SAVE_FAILED));
 
     }
 
@@ -116,7 +116,7 @@ public class DataPermissionController {
     public ShenyuAdminResult deleteSelector(@RequestBody final DataPermissionDTO dataPermissionDTO) {
         return Optional.ofNullable(dataPermissionDTO)
                 .map(item -> ShenyuAdminResult.success(ShenyuResultMessage.DELETE_SUCCESS, dataPermissionService.deleteSelector(dataPermissionDTO)))
-                .orElse(ShenyuAdminResult.error(ShenyuResultMessage.DELETE_SUCCESS));
+                .orElseGet(() -> ShenyuAdminResult.error(ShenyuResultMessage.DELETE_SUCCESS));
 
     }
 
@@ -129,7 +129,7 @@ public class DataPermissionController {
     public ShenyuAdminResult saveRule(@RequestBody final DataPermissionDTO dataPermissionDTO) {
         return Optional.ofNullable(dataPermissionDTO)
                 .map(item -> ShenyuAdminResult.success(ShenyuResultMessage.SAVE_SUCCESS, dataPermissionService.createRule(dataPermissionDTO)))
-                .orElse(ShenyuAdminResult.error(ShenyuResultMessage.SAVE_FAILED));
+                .orElseGet(() -> ShenyuAdminResult.error(ShenyuResultMessage.SAVE_FAILED));
     }
 
     /**
@@ -141,7 +141,7 @@ public class DataPermissionController {
     public ShenyuAdminResult deleteRule(@RequestBody final DataPermissionDTO dataPermissionDTO) {
         return Optional.ofNullable(dataPermissionDTO)
                 .map(item -> ShenyuAdminResult.success(ShenyuResultMessage.DELETE_SUCCESS, dataPermissionService.deleteRule(dataPermissionDTO)))
-                .orElse(ShenyuAdminResult.error(ShenyuResultMessage.DELETE_SUCCESS));
+                .orElseGet(() -> ShenyuAdminResult.error(ShenyuResultMessage.DELETE_SUCCESS));
 
     }
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/PermissionController.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/PermissionController.java
@@ -50,6 +50,6 @@ public class PermissionController {
         PermissionMenuVO permissionMenuVO = permissionService.getPermissionMenu(token);
         return Optional.ofNullable(permissionMenuVO)
                 .map(item -> ShenyuAdminResult.success(ShenyuResultMessage.MENU_SUCCESS, item))
-                .orElse(ShenyuAdminResult.error(ShenyuResultMessage.MENU_FAILED));
+                .orElseGet(() -> ShenyuAdminResult.error(ShenyuResultMessage.MENU_FAILED));
     }
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/MetaDataServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/MetaDataServiceImpl.java
@@ -156,7 +156,7 @@ public class MetaDataServiceImpl implements MetaDataService {
 
     @Override
     public MetaDataVO findById(final String id) {
-        return Optional.ofNullable(MetaDataTransfer.INSTANCE.mapToVO(metaDataMapper.selectById(id))).orElse(new MetaDataVO());
+        return Optional.ofNullable(MetaDataTransfer.INSTANCE.mapToVO(metaDataMapper.selectById(id))).orElseGet(MetaDataVO::new);
     }
 
     @Override

--- a/shenyu-plugin/shenyu-plugin-monitor/src/main/java/org/apache/shenyu/plugin/monitor/MonitorPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-monitor/src/main/java/org/apache/shenyu/plugin/monitor/MonitorPlugin.java
@@ -50,7 +50,7 @@ public class MonitorPlugin extends AbstractShenyuPlugin {
         MetricsReporter.counterIncrement(LabelNames.REQUEST_TOTAL);
         MetricsReporter.counterIncrement(LabelNames.HTTP_REQUEST_TOTAL, new String[]{exchange.getRequest().getURI().getPath(), exchange.getRequest().getMethodValue()});
         ShenyuContext shenyuContext = exchange.getAttribute(Constants.CONTEXT);
-        LocalDateTime startDateTime = Optional.ofNullable(shenyuContext).map(ShenyuContext::getStartDateTime).orElse(LocalDateTime.now());
+        LocalDateTime startDateTime = Optional.ofNullable(shenyuContext).map(ShenyuContext::getStartDateTime).orElseGet(LocalDateTime::now);
         return chain.execute(exchange).doOnSuccess(e -> responseCommitted(exchange, startDateTime))
                 .doOnError(throwable -> responseCommitted(exchange, startDateTime));
     }

--- a/shenyu-plugin/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/algorithm/RateLimiterAlgorithmFactory.java
+++ b/shenyu-plugin/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/algorithm/RateLimiterAlgorithmFactory.java
@@ -33,6 +33,6 @@ public class RateLimiterAlgorithmFactory {
      * @return the rate limiter algorithm
      */
     public static RateLimiterAlgorithm<?> newInstance(final String name) {
-        return Optional.ofNullable(ExtensionLoader.getExtensionLoader(RateLimiterAlgorithm.class).getJoin(name)).orElse(new TokenBucketRateLimiterAlgorithm());
+        return Optional.ofNullable(ExtensionLoader.getExtensionLoader(RateLimiterAlgorithm.class).getJoin(name)).orElseGet(TokenBucketRateLimiterAlgorithm::new);
     }
 }


### PR DESCRIPTION
##Motivation
- Replace orElse with orElseGet to avoid calling too many times if the else is not a constant variable.