### PR TITLE
[ISSUE #2001] support external cros filter config. 

### DIFF
--- a/shenyu-common/src/main/java/org/apache/shenyu/common/config/ShenyuConfig.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/config/ShenyuConfig.java
@@ -17,8 +17,14 @@
 
 package org.apache.shenyu.common.config;
 
+import org.springframework.util.StringUtils;
+
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The type shenyu config.
@@ -36,7 +42,9 @@ public class ShenyuConfig {
     private Scheduler scheduler = new Scheduler();
     
     private UpstreamCheck upstreamCheck = new UpstreamCheck();
-    
+
+    private CrosFilterConfig crosFilterConfig = new CrosFilterConfig();
+
     /**
      * Gets switch config.
      *
@@ -144,7 +152,25 @@ public class ShenyuConfig {
     public void setUpstreamCheck(final UpstreamCheck upstreamCheck) {
         this.upstreamCheck = upstreamCheck;
     }
-    
+
+    /**
+     * Gets crosFilterConfig.
+     *
+     * @return the crosFilterConfig
+     */
+    public CrosFilterConfig getCrosFilterConfig() {
+        return crosFilterConfig;
+    }
+
+    /**
+     * Sets crosFilterConfig.
+     *
+     * @param crosFilterConfig the crosFilterConfig
+     */
+    public void setCrosFilterConfig(final CrosFilterConfig crosFilterConfig) {
+        this.crosFilterConfig = crosFilterConfig;
+    }
+
     /**
      * The type Scheduler.
      */
@@ -580,6 +606,170 @@ public class ShenyuConfig {
          */
         public void setPrintInterval(final Integer printInterval) {
             this.printInterval = printInterval;
+        }
+    }
+
+    /**
+     * The Cros Filter Config.
+     */
+    public static class CrosFilterConfig {
+
+        private static final Set<String> DEFAULT_ALLOWED_HEADERS;
+
+        static {
+            DEFAULT_ALLOWED_HEADERS = new HashSet<String>() {
+                {
+                    add("x-requested-with");
+                    add("authorization");
+                    add("Content-Type");
+                    add("Authorization");
+                    add("credential");
+                    add("X-XSRF-TOKEN");
+                    add("token");
+                    add("username");
+                    add("client");
+                }
+            };
+        }
+
+        /**
+         * Comma-separated of “header”.
+         */
+        private String allowedHeaders = "";
+
+        /**
+         * Comma-separated of “method”.
+         */
+        private String allowedMethods = "*";
+
+        private String allowedOrigin = "*";
+
+        private String allowedExpose = "*";
+
+        private String maxAge = "18000";
+
+        private boolean allowCredentials = true;
+
+        /**
+         * wrapper the headers.
+         *
+         * @param headers headers
+         * @return wrapped headers
+         */
+        private String wrapperHeaders(final String headers) {
+            final Set<String> headerSet = DEFAULT_ALLOWED_HEADERS;
+            if (StringUtils.hasText(headers)) {
+                headerSet.addAll(Stream.of(headers.split(",")).collect(Collectors.toSet()));
+            }
+            return String.join(",", headerSet);
+        }
+
+        /**
+         * Gets the value of allowedHeaders.
+         *
+         * @return the value of allowedHeaders
+         */
+        public String getAllowedHeaders() {
+            return allowedHeaders = wrapperHeaders(allowedHeaders);
+        }
+
+        /**
+         * Sets the allowedHeaders.
+         *
+         * @param allowedHeaders allowedHeaders
+         */
+        public void setAllowedHeaders(final String allowedHeaders) {
+            this.allowedHeaders = wrapperHeaders(allowedHeaders);
+        }
+
+        /**
+         * Gets the value of allowedMethods.
+         *
+         * @return the value of allowedMethods
+         */
+        public String getAllowedMethods() {
+            return allowedMethods;
+        }
+
+        /**
+         * Sets the allowedMethods.
+         *
+         * @param allowedMethods allowedMethods
+         */
+        public void setAllowedMethods(final String allowedMethods) {
+            this.allowedMethods = allowedMethods;
+        }
+
+        /**
+         * Gets the value of allowedOrigin.
+         *
+         * @return the value of allowedOrigin
+         */
+        public String getAllowedOrigin() {
+            return allowedOrigin;
+        }
+
+        /**
+         * Sets the allowedOrigin.
+         *
+         * @param allowedOrigin allowedOrigin
+         */
+        public void setAllowedOrigin(final String allowedOrigin) {
+            this.allowedOrigin = allowedOrigin;
+        }
+
+        /**
+         * Gets the value of allowedExpose.
+         *
+         * @return the value of allowedExpose
+         */
+        public String getAllowedExpose() {
+            return allowedExpose;
+        }
+
+        /**
+         * Sets the allowedExpose.
+         *
+         * @param allowedExpose allowedExpose
+         */
+        public void setAllowedExpose(final String allowedExpose) {
+            this.allowedExpose = allowedExpose;
+        }
+
+        /**
+         * Gets the value of maxAge.
+         *
+         * @return the value of maxAge
+         */
+        public String getMaxAge() {
+            return maxAge;
+        }
+
+        /**
+         * Sets the maxAge.
+         *
+         * @param maxAge maxAge
+         */
+        public void setMaxAge(final String maxAge) {
+            this.maxAge = maxAge;
+        }
+
+        /**
+         * Gets the value of allowCredentials.
+         *
+         * @return the value of allowCredentials
+         */
+        public boolean isAllowCredentials() {
+            return allowCredentials;
+        }
+
+        /**
+         * Sets the allowCredentials.
+         *
+         * @param allowCredentials allowCredentials
+         */
+        public void setAllowCredentials(final boolean allowCredentials) {
+            this.allowCredentials = allowCredentials;
         }
     }
 }

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/java/org/apache/shenyu/springboot/starter/gateway/ShenyuConfiguration.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/java/org/apache/shenyu/springboot/starter/gateway/ShenyuConfiguration.java
@@ -164,13 +164,14 @@ public class ShenyuConfiguration {
      * 1. Customize webflux's cross-domain requests.
      * 2. Spring bean Sort is greater than -1.
      *
+     * @param shenyuConfig the shenyu config
      * @return the web filter
      */
     @Bean
     @Order(-100)
     @ConditionalOnProperty(name = "shenyu.switchConfig.cross", havingValue = "true")
-    public WebFilter crossFilter() {
-        return new CrossFilter();
+    public WebFilter crossFilter(final ShenyuConfig shenyuConfig) {
+        return new CrossFilter(shenyuConfig.getCrosFilterConfig());
     }
     
     /**

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/filter/CrossFilter.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/filter/CrossFilter.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.web.filter;
 
+import org.apache.shenyu.common.config.ShenyuConfig;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -33,15 +34,11 @@ import reactor.core.publisher.Mono;
  */
 public class CrossFilter implements WebFilter {
 
-    private static final String ALLOWED_HEADERS = "x-requested-with, authorization, Content-Type, Authorization, credential, X-XSRF-TOKEN,token,username,client";
+    private final ShenyuConfig.CrosFilterConfig filterConfig;
 
-    private static final String ALLOWED_METHODS = "*";
-
-    private static final String ALLOWED_ORIGIN = "*";
-
-    private static final String ALLOWED_EXPOSE = "*";
-
-    private static final String MAX_AGE = "18000";
+    public CrossFilter(final ShenyuConfig.CrosFilterConfig filterConfig) {
+        this.filterConfig = filterConfig;
+    }
 
     @Override
     @SuppressWarnings("all")
@@ -50,12 +47,12 @@ public class CrossFilter implements WebFilter {
         if (CorsUtils.isCorsRequest(request)) {
             ServerHttpResponse response = exchange.getResponse();
             HttpHeaders headers = response.getHeaders();
-            headers.add("Access-Control-Allow-Origin", ALLOWED_ORIGIN);
-            headers.add("Access-Control-Allow-Methods", ALLOWED_METHODS);
-            headers.add("Access-Control-Max-Age", MAX_AGE);
-            headers.add("Access-Control-Allow-Headers", ALLOWED_HEADERS);
-            headers.add("Access-Control-Expose-Headers", ALLOWED_EXPOSE);
-            headers.add("Access-Control-Allow-Credentials", "true");
+            headers.add("Access-Control-Allow-Origin", this.filterConfig.getAllowedOrigin());
+            headers.add("Access-Control-Allow-Methods", this.filterConfig.getAllowedMethods());
+            headers.add("Access-Control-Max-Age", this.filterConfig.getMaxAge());
+            headers.add("Access-Control-Allow-Headers", this.filterConfig.getAllowedHeaders());
+            headers.add("Access-Control-Expose-Headers", this.filterConfig.getAllowedExpose());
+            headers.add("Access-Control-Allow-Credentials", String.valueOf(this.filterConfig.isAllowCredentials()));
             if (request.getMethod() == HttpMethod.OPTIONS) {
                 response.setStatusCode(HttpStatus.OK);
                 return Mono.empty();

--- a/shenyu-web/src/test/java/org/apache/shenyu/web/filter/CrossFilterTest.java
+++ b/shenyu-web/src/test/java/org/apache/shenyu/web/filter/CrossFilterTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.web.filter;
 
+import org.apache.shenyu.common.config.ShenyuConfig;
 import org.junit.Test;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
@@ -43,7 +44,7 @@ public final class CrossFilterTest {
                 .build());
         WebFilterChain chainNoHeader = mock(WebFilterChain.class);
         when(chainNoHeader.filter(exchangeNoHeader)).thenReturn(Mono.empty());
-        CrossFilter filterNoHeader = new CrossFilter();
+        CrossFilter filterNoHeader = new CrossFilter(new ShenyuConfig.CrosFilterConfig());
         StepVerifier.create(filterNoHeader.filter(exchangeNoHeader, chainNoHeader))
                 .expectSubscription()
                 .verifyComplete();
@@ -54,7 +55,7 @@ public final class CrossFilterTest {
                 .build());
         WebFilterChain chainNormal = mock(WebFilterChain.class);
         when(chainNormal.filter(exchangeNormal)).thenReturn(Mono.empty());
-        CrossFilter filterNormal = new CrossFilter();
+        CrossFilter filterNormal = new CrossFilter(new ShenyuConfig.CrosFilterConfig());
         StepVerifier.create(filterNormal.filter(exchangeNormal, chainNormal))
                 .expectSubscription()
                 .verifyComplete();
@@ -65,7 +66,7 @@ public final class CrossFilterTest {
                 .build());
         WebFilterChain chainOption = mock(WebFilterChain.class);
         when(chainOption.filter(exchangeOption)).thenReturn(Mono.empty());
-        CrossFilter filterOption = new CrossFilter();
+        CrossFilter filterOption = new CrossFilter(new ShenyuConfig.CrosFilterConfig());
         StepVerifier.create(filterOption.filter(exchangeOption, chainOption))
                 .expectSubscription()
                 .verifyComplete();

--- a/shenyu-web/src/test/java/org/apache/shenyu/web/filter/WebSocketParamFilterTest.java
+++ b/shenyu-web/src/test/java/org/apache/shenyu/web/filter/WebSocketParamFilterTest.java
@@ -34,6 +34,7 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
 import java.util.Collections;
 
 import static org.mockito.Mockito.mock;

--- a/shenyu-web/src/test/java/org/apache/shenyu/web/handler/ShenyuWebHandlerTest.java
+++ b/shenyu-web/src/test/java/org/apache/shenyu/web/handler/ShenyuWebHandlerTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.shenyu.web.handler;
 
+import org.apache.shenyu.common.config.ShenyuConfig;
 import org.apache.shenyu.common.constant.Constants;
 import org.apache.shenyu.plugin.api.ShenyuPlugin;
 import org.apache.shenyu.plugin.api.context.ShenyuContext;
-import org.apache.shenyu.common.config.ShenyuConfig;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
using `shenyu.cros-filter-config.*` config the cors filter:
```yml
shenyu:
  cros-filter-config:
    allowed-headers: qicz, custom
    allowed-expose: *
    allowed-methods: *
    allowed-origin: *
    max-age: 18000
```

the `allowed-headers` default is `x-requested-with, authorization, Content-Type, Authorization, credential, X-XSRF-TOKEN, token, username, client`.

 the external config will append to the `allowed-headers`.  the example of `allowed-headers` = `x-requested-with, authorization, Content-Type, Authorization, credential, X-XSRF-TOKEN, token, username, client,  qicz, custom`.
