### PR TITLE
[ISSUE #2014] validate the context path, fix "String index out of range" bug.

### DIFF
--- a/shenyu-plugin/shenyu-plugin-context-path/src/main/java/org/apache/shenyu/plugin/context/path/ContextPathPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-context-path/src/main/java/org/apache/shenyu/plugin/context/path/ContextPathPlugin.java
@@ -26,6 +26,9 @@ import org.apache.shenyu.common.enums.PluginEnum;
 import org.apache.shenyu.common.enums.RpcTypeEnum;
 import org.apache.shenyu.plugin.api.ShenyuPluginChain;
 import org.apache.shenyu.plugin.api.context.ShenyuContext;
+import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
+import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
+import org.apache.shenyu.plugin.api.utils.WebFluxResultUtils;
 import org.apache.shenyu.plugin.base.AbstractShenyuPlugin;
 import org.apache.shenyu.plugin.base.utils.CacheKeyUtils;
 import org.apache.shenyu.plugin.context.path.handler.ContextPathPluginDataHandler;
@@ -51,6 +54,16 @@ public class ContextPathPlugin extends AbstractShenyuPlugin {
         if (Objects.isNull(contextMappingHandle)) {
             LOG.error("context path rule configuration is null ：{}", rule);
             return chain.execute(exchange);
+        }
+        if (StringUtils.isNoneBlank(contextMappingHandle.getContextPath())) {
+            if (!shenyuContext.getPath().startsWith(contextMappingHandle.getContextPath())) {
+                LOG.error("the context path '{}' is invalid.", contextMappingHandle.getContextPath());
+                Object error = ShenyuResultWrap.error(ShenyuResultEnum.CONTEXT_PATH_ERROR.getCode(),
+                        String.format("%s [invalid context path:'%s']",
+                                ShenyuResultEnum.CONTEXT_PATH_ERROR.getMsg(),
+                                contextMappingHandle.getContextPath()), null);
+                return WebFluxResultUtils.result(exchange, error);
+            }
         }
         buildContextPath(shenyuContext, contextMappingHandle);
         return chain.execute(exchange);


### PR DESCRIPTION
Fix #2014 , validate the `context path` before `buildContextPath`.

if the `context path` is invalid response follow error:

```json
{
"code": -111,
"message": "The context path illegal, please check the context path mapping plugin! [invalid context path:'/**']",
"data": null
}
```