### PR TITLE
[ISSUE #2015] Support sign plugin custom dynamic sign provider.

### DIFF
--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/sign/DefaultSignProvider.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/sign/DefaultSignProvider.java
@@ -15,20 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.shenyu.plugin.api;
+package org.apache.shenyu.plugin.api.sign;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.web.server.ServerWebExchange;
+import org.apache.shenyu.common.utils.SignUtils;
+
+import java.util.Map;
 
 /**
- * The interface Sign service.
+ * The Sign plugin default signer.
  */
-public interface SignService {
+public class DefaultSignProvider implements SignProvider {
 
     /**
-     * Sign verify pair.
-     * @param exchange   the exchange
-     * @return the pair
+     * acquired sign.
+     *
+     * @param signKey sign key
+     * @param params  params
+     * @return sign
      */
-    Pair<Boolean, String> signVerify(ServerWebExchange exchange);
+    @Override
+    public String generateSign(final String signKey, final Map<String, String> params) {
+        return SignUtils.generateSign(signKey, params);
+    }
 }

--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/sign/ShenyuSignProviderWrap.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/sign/ShenyuSignProviderWrap.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.api.sign;
+
+import org.apache.shenyu.plugin.api.utils.SpringBeanUtils;
+
+import java.util.Map;
+
+/**
+ * The shenyu sign plugin sign provider warp.
+ */
+public final class ShenyuSignProviderWrap {
+
+    /**
+     * find the sign provider object.
+     *
+     * @return the sign provider
+     */
+    public static SignProvider signProvider() {
+        return SpringBeanUtils.getInstance().getBean(SignProvider.class);
+    }
+
+    /**
+     * acquired sign.
+     *
+     * @param signKey sign key
+     * @param params  params
+     * @return sign
+     */
+    public static String generateSign(final String signKey, final Map<String, String> params) {
+        return signProvider().generateSign(signKey, params);
+    }
+}

--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/sign/SignProvider.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/sign/SignProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.api.sign;
+
+import java.util.Map;
+
+/**
+ * The Sign plugin sign provider.
+ */
+public interface SignProvider {
+
+    /**
+     * acquired sign.
+     *
+     * @param signKey sign key
+     * @param params  params
+     * @return sign
+     */
+    String generateSign(String signKey, Map<String, String> params);
+}

--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/sign/SignService.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/sign/SignService.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.api.sign;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * The interface Sign service.
+ */
+public interface SignService {
+
+    /**
+     * Sign verify pair.
+     * @param exchange   the exchange
+     * @return the pair
+     */
+    Pair<Boolean, String> signVerify(ServerWebExchange exchange);
+}

--- a/shenyu-plugin/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/SignPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/SignPlugin.java
@@ -26,7 +26,7 @@ import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
 import org.apache.shenyu.plugin.api.ShenyuPluginChain;
 import org.apache.shenyu.plugin.base.AbstractShenyuPlugin;
 import org.apache.shenyu.plugin.api.utils.WebFluxResultUtils;
-import org.apache.shenyu.plugin.api.SignService;
+import org.apache.shenyu.plugin.api.sign.SignService;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 

--- a/shenyu-plugin/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/service/DefaultSignService.java
+++ b/shenyu-plugin/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/service/DefaultSignService.java
@@ -18,10 +18,6 @@
 package org.apache.shenyu.plugin.sign.service;
 
 import com.google.common.collect.Maps;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -33,16 +29,21 @@ import org.apache.shenyu.common.dto.PluginData;
 import org.apache.shenyu.common.enums.PluginEnum;
 import org.apache.shenyu.common.utils.DateUtils;
 import org.apache.shenyu.common.utils.PathMatchUtils;
-import org.apache.shenyu.common.utils.SignUtils;
-import org.apache.shenyu.plugin.api.SignService;
 import org.apache.shenyu.plugin.api.context.ShenyuContext;
 import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
+import org.apache.shenyu.plugin.api.sign.ShenyuSignProviderWrap;
+import org.apache.shenyu.plugin.api.sign.SignService;
 import org.apache.shenyu.plugin.base.cache.BaseDataCache;
 import org.apache.shenyu.plugin.sign.cache.SignAuthDataCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.server.ServerWebExchange;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * The type Default sign service.
@@ -107,7 +108,7 @@ public class DefaultSignService implements SignService {
                 return Pair.of(Boolean.FALSE, Constants.SIGN_PATH_NOT_EXIST);
             }
         }
-        String sigKey = SignUtils.generateSign(appAuthData.getAppSecret(), buildParamsMap(shenyuContext));
+        String sigKey = ShenyuSignProviderWrap.generateSign(appAuthData.getAppSecret(), buildParamsMap(shenyuContext));
         boolean result = Objects.equals(sigKey, shenyuContext.getSign());
         if (!result) {
             LOG.error("the SignUtils generated signature value is:{},the accepted value is:{}", sigKey, shenyuContext.getSign());

--- a/shenyu-plugin/shenyu-plugin-sign/src/test/java/org/apache/shenyu/plugin/sign/SignPluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-sign/src/test/java/org/apache/shenyu/plugin/sign/SignPluginTest.java
@@ -20,7 +20,7 @@ package org.apache.shenyu.plugin.sign;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.shenyu.common.dto.RuleData;
 import org.apache.shenyu.common.dto.SelectorData;
-import org.apache.shenyu.plugin.api.SignService;
+import org.apache.shenyu.plugin.api.sign.SignService;
 import org.apache.shenyu.plugin.api.ShenyuPluginChain;
 
 import org.junit.Before;

--- a/shenyu-plugin/shenyu-plugin-sign/src/test/java/org/apache/shenyu/plugin/sign/service/DefaultSignServiceTest.java
+++ b/shenyu-plugin/shenyu-plugin-sign/src/test/java/org/apache/shenyu/plugin/sign/service/DefaultSignServiceTest.java
@@ -26,9 +26,12 @@ import org.apache.shenyu.common.dto.AuthPathData;
 import org.apache.shenyu.common.dto.PluginData;
 import org.apache.shenyu.common.enums.PluginEnum;
 import org.apache.shenyu.common.utils.SignUtils;
-import org.apache.shenyu.plugin.api.SignService;
+import org.apache.shenyu.plugin.api.sign.DefaultSignProvider;
+import org.apache.shenyu.plugin.api.sign.SignService;
 import org.apache.shenyu.plugin.api.context.ShenyuContext;
 import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
+import org.apache.shenyu.plugin.api.sign.SignProvider;
+import org.apache.shenyu.plugin.api.utils.SpringBeanUtils;
 import org.apache.shenyu.plugin.base.cache.BaseDataCache;
 import org.apache.shenyu.plugin.sign.cache.SignAuthDataCache;
 
@@ -38,12 +41,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.server.ServerWebExchange;
 
 import java.util.Collections;
 import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * DefaultSignService Test.
@@ -101,6 +108,10 @@ public final class DefaultSignServiceTest {
         this.passed.setAppKey(appKey);
         this.passed.setContextPath("/test-api");
         this.passed.setRealUrl("/demo/test");
+
+        ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+        SpringBeanUtils.getInstance().setCfgContext(context);
+        when(context.getBean(SignProvider.class)).thenReturn(new DefaultSignProvider());
     }
 
     @Test

--- a/shenyu-plugin/shenyu-plugin-sign/src/test/java/org/apache/shenyu/plugin/sign/sign/DefaultSignProviderTest.java
+++ b/shenyu-plugin/shenyu-plugin-sign/src/test/java/org/apache/shenyu/plugin/sign/sign/DefaultSignProviderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.sign.sign;
+
+import org.apache.shenyu.plugin.api.sign.DefaultSignProvider;
+import org.apache.shenyu.plugin.api.sign.ShenyuSignProviderWrap;
+import org.apache.shenyu.plugin.api.sign.SignProvider;
+import org.apache.shenyu.plugin.api.utils.SpringBeanUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The Shenyu default sign provider test.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultSignProviderTest {
+
+    @Before
+    public void setUp() {
+        ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+        SpringBeanUtils.getInstance().setCfgContext(context);
+        when(context.getBean(SignProvider.class)).thenReturn(new DefaultSignProvider());
+    }
+
+    @Test
+    public void testGenerateSign() {
+        Map<String, String> params = new HashMap<>();
+        params.put("a", "1");
+        params.put("b", "2");
+        assertNotNull(ShenyuSignProviderWrap.generateSign("test", params));
+    }
+}

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/src/main/java/org/apache/shenyu/springboot/starter/plugin/sign/SignPluginConfiguration.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/src/main/java/org/apache/shenyu/springboot/starter/plugin/sign/SignPluginConfiguration.java
@@ -17,8 +17,10 @@
 
 package org.apache.shenyu.springboot.starter.plugin.sign;
 
-import org.apache.shenyu.plugin.api.SignService;
+import org.apache.shenyu.plugin.api.sign.DefaultSignProvider;
+import org.apache.shenyu.plugin.api.sign.SignService;
 import org.apache.shenyu.plugin.api.ShenyuPlugin;
+import org.apache.shenyu.plugin.api.sign.SignProvider;
 import org.apache.shenyu.plugin.sign.SignPlugin;
 import org.apache.shenyu.plugin.sign.service.DefaultSignService;
 import org.apache.shenyu.plugin.sign.subscriber.SignAuthDataSubscriber;
@@ -43,6 +45,17 @@ public class SignPluginConfiguration {
     @ConditionalOnMissingBean(value = SignService.class, search = SearchStrategy.ALL)
     public SignService signService() {
         return new DefaultSignService();
+    }
+
+    /**
+     * Sign plugin signer.
+     *
+     * @return the signer
+     */
+    @Bean
+    @ConditionalOnMissingBean(value = SignProvider.class, search = SearchStrategy.ALL)
+    public SignProvider signer() {
+        return new DefaultSignProvider();
     }
     
     /**

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/src/test/java/org/apache/shenyu/springboot/starter/plugin/sign/SignPluginConfigurationTest.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/src/test/java/org/apache/shenyu/springboot/starter/plugin/sign/SignPluginConfigurationTest.java
@@ -18,7 +18,7 @@
 package org.apache.shenyu.springboot.starter.plugin.sign;
 
 import org.apache.shenyu.common.enums.PluginEnum;
-import org.apache.shenyu.plugin.api.SignService;
+import org.apache.shenyu.plugin.api.sign.SignService;
 import org.apache.shenyu.plugin.api.ShenyuPlugin;
 import org.apache.shenyu.sync.data.api.AuthDataSubscriber;
 import org.junit.Test;


### PR DESCRIPTION
this pr is optimized for #2015 .

you can implement the `org.apache.shenyu.plugin.api.sign.SignProvider` define the custom sign provider sign logic. 

the `org.apache.shenyu.plugin.api.sign.DefaultSignProvider` use the `org.apache.shenyu.common.utils.SignUtils#generateSign`.

 