### PR TITLE
[ISSUE #2025] feature plugin: add request id plugin.

### DIFF
--- a/shenyu-common/src/main/java/org/apache/shenyu/common/config/ShenyuConfig.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/config/ShenyuConfig.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.common.config;
 
+import org.apache.shenyu.common.enums.ThreadShareDataEnum;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
@@ -629,6 +630,8 @@ public class ShenyuConfig {
                     add("token");
                     add("username");
                     add("client");
+                    // request id
+                    add(ThreadShareDataEnum.REQUEST_ID.getName());
                 }
             };
         }

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java
@@ -31,144 +31,149 @@ public enum PluginEnum {
     GLOBAL(10, 0, "global"),
 
     /**
+     * RequestId plugin enum.
+     */
+    REQUEST_ID(20, 0, "request-id"),
+
+    /**
      * Sign plugin enum.
      */
-    SIGN(20, 0, "sign"),
+    SIGN(30, 0, "sign"),
 
     /**
      * Jwt plugin enum.
      */
-    JWT(30, 0, "jwt"),
+    JWT(40, 0, "jwt"),
 
     /**
      * OAuth2 plugin enum.
      */
-    OAUTH2(40, 0, "oauth2"),
+    OAUTH2(50, 0, "oauth2"),
 
     /**
      * Waf plugin enum.
      */
-    WAF(50, 0, "waf"),
+    WAF(60, 0, "waf"),
 
     /**
      * Rate limiter plugin enum.
      */
-    RATE_LIMITER(60, 0, "rate_limiter"),
+    RATE_LIMITER(70, 0, "rate_limiter"),
 
     /**
      * Param mapping plugin enum.
      */
-    PARAM_MAPPING(70, 0, "param_mapping"),
+    PARAM_MAPPING(80, 0, "param_mapping"),
 
     /**
      * Context path plugin enum.
      */
-    CONTEXT_PATH(80, 0, "context_path"),
+    CONTEXT_PATH(90, 0, "context_path"),
 
     /**
      * Rewrite plugin enum.
      */
-    REWRITE(90, 0, "rewrite"),
+    REWRITE(100, 0, "rewrite"),
 
     /**
      * Cryptor request plugin enum.
      */
-    CRYPTOR_REQUEST(100, 0, "cryptor_request"),
+    CRYPTOR_REQUEST(110, 0, "cryptor_request"),
 
     /**
      * Redirect plugin enum.
      */
-    REDIRECT(110, 0, "redirect"),
+    REDIRECT(120, 0, "redirect"),
 
     /**
      * Request plugin enum.
      */
-    REQUEST(120, 0, "request"),
+    REQUEST(130, 0, "request"),
 
     /**
      * ModifyResponse plugin enum.
      */
-    MODIFY_RESPONSE(130, 0, "modifyResponse"),
+    MODIFY_RESPONSE(140, 0, "modifyResponse"),
 
     /**
      * Hystrix plugin enum.
      */
-    HYSTRIX(140, 0, "hystrix"),
+    HYSTRIX(150, 0, "hystrix"),
 
     /**
      * Sentinel plugin enum.
      */
-    SENTINEL(150, 0, "sentinel"),
+    SENTINEL(160, 0, "sentinel"),
 
     /**
      * Resilence4J plugin enum.
      */
-    RESILIENCE4J(160, 0, "resilience4j"),
+    RESILIENCE4J(170, 0, "resilience4j"),
 
     /**
      * Logging plugin enum.
      */
-    LOGGING(170, 0, "logging"),
+    LOGGING(180, 0, "logging"),
 
     /**
      * Divide plugin enum.
      */
-    DIVIDE(180, 0, "divide"),
+    DIVIDE(190, 0, "divide"),
 
     /**
      * springCloud plugin enum.
      */
-    SPRING_CLOUD(190, 0, "springCloud"),
+    SPRING_CLOUD(200, 0, "springCloud"),
 
     /**
      * webSocket plugin enum.
      */
-    WEB_SOCKET(200, 0, "websocket"),
+    WEB_SOCKET(210, 0, "websocket"),
 
     /**
      * Param transform plugin enum.
      */
-    PARAM_TRANSFORM(210, 0, "paramTransform"),
+    PARAM_TRANSFORM(220, 0, "paramTransform"),
 
     /**
      * Dubbo plugin enum.
      */
-    DUBBO(220, 0, "dubbo"),
+    DUBBO(230, 0, "dubbo"),
 
     /**
      * Sofa plugin enum.
      */
-    SOFA(230, 0, "sofa"),
+    SOFA(240, 0, "sofa"),
 
     /**
      * Tars plugin enum.
      */
-    TARS(240, 0, "tars"),
+    TARS(250, 0, "tars"),
 
     /**
      * GPRC plugin enum.
      */
-    GRPC(250, 0, "grpc"),
+    GRPC(260, 0, "grpc"),
 
     /**
      * Motan plugin enum.
      */
-    MOTAN(260, 0, "motan"),
+    MOTAN(270, 0, "motan"),
 
     /**
      * Monitor plugin enum.
      */
-    MONITOR(270, 0, "monitor"),
+    MONITOR(280, 0, "monitor"),
 
     /**
      * Cryptor response plugin enum.
      */
-    CRYPTOR_RESPONSE(280, 0, "cryptor_response"),
+    CRYPTOR_RESPONSE(290, 0, "cryptor_response"),
 
     /**
      * Response plugin enum.
      */
-    RESPONSE(290, 0, "response");
+    RESPONSE(300, 0, "response");
 
     private final int code;
 

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/enums/ThreadShareDataEnum.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/enums/ThreadShareDataEnum.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.common.enums;
+
+/**
+ * thread share data enum.
+ */
+public enum ThreadShareDataEnum {
+
+    /**
+     * request id.
+     */
+    REQUEST_ID("Request-Id");
+
+    /**
+     * share data name.
+     */
+    private final String name;
+
+    /**
+     * all args constructor.
+     *
+     * @param name    name
+     */
+    ThreadShareDataEnum(final String name) {
+        this.name = name;
+    }
+
+    /**
+     * get name.
+     *
+     * @return name
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/shenyu-plugin/pom.xml
+++ b/shenyu-plugin/pom.xml
@@ -59,5 +59,6 @@
         <module>shenyu-plugin-param-mapping</module>
         <module>shenyu-plugin-cryptor</module>
         <module>shenyu-plugin-websocket</module>
+        <module>shenyu-plugin-request-id</module>
     </modules>
 </project>

--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/request/id/DefaultRequestIdGenerator.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/request/id/DefaultRequestIdGenerator.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.api.request.id;
+
+import java.util.UUID;
+
+/**
+ * DefaultRequestIdGenerator.
+ */
+public class DefaultRequestIdGenerator implements RequestIdGenerator {
+
+    /**
+     * Gets new id.
+     * default using the uuid.
+     *
+     * @return the new id
+     */
+    @Override
+    public String newId() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/request/id/RequestIdGenerator.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/request/id/RequestIdGenerator.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.api.request.id;
+
+/**
+ * RequestIdGenerator.
+ */
+public interface RequestIdGenerator {
+
+    /**
+     * Gets new id.
+     *
+     * @return the new id
+     */
+    String newId();
+}

--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/request/id/ShenyuRequestIdWrap.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/request/id/ShenyuRequestIdWrap.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.api.request.id;
+
+import org.apache.shenyu.common.enums.ThreadShareDataEnum;
+import org.apache.shenyu.common.utils.ThreadShareUtils;
+import org.apache.shenyu.plugin.api.utils.SpringBeanUtils;
+
+/**
+ * ShenyuRequestIdWrap.
+ */
+public final class ShenyuRequestIdWrap {
+
+    /**
+     * Gets new request id.
+     *
+     * @return the new request id
+     */
+    public static String newRequestId() {
+        return SpringBeanUtils.getInstance().getBean(RequestIdGenerator.class).newId();
+    }
+
+    /**
+     * Gets the request id.
+     *
+     * @return the the request id
+     */
+    public static String getRequestId() {
+        return ThreadShareUtils.getRemove(ThreadShareDataEnum.REQUEST_ID.getName());
+    }
+}

--- a/shenyu-plugin/shenyu-plugin-request-id/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-request-id/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shenyu-plugin</artifactId>
+        <groupId>org.apache.shenyu</groupId>
+        <version>2.4.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shenyu-plugin-request-id</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shenyu</groupId>
+            <artifactId>shenyu-plugin-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/shenyu-plugin/shenyu-plugin-request-id/src/main/java/org/apache/shenyu/plugin/request/id/RequestIdPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-request-id/src/main/java/org/apache/shenyu/plugin/request/id/RequestIdPlugin.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.request.id;
+
+import org.apache.shenyu.common.enums.PluginEnum;
+import org.apache.shenyu.common.enums.ThreadShareDataEnum;
+import org.apache.shenyu.common.utils.ThreadShareUtils;
+import org.apache.shenyu.plugin.api.ShenyuPlugin;
+import org.apache.shenyu.plugin.api.ShenyuPluginChain;
+import org.apache.shenyu.plugin.api.request.id.ShenyuRequestIdWrap;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * RequestIdPlugin.
+ */
+public class RequestIdPlugin implements ShenyuPlugin {
+
+    @Override
+    public Mono<Void> execute(final ServerWebExchange exchange, final ShenyuPluginChain chain) {
+        String requestId = ShenyuRequestIdWrap.newRequestId();
+        String requestIdName = ThreadShareDataEnum.REQUEST_ID.getName();
+        // put the thread share data
+        ThreadShareUtils.put(requestIdName, requestId);
+        ServerWebExchange modifiedExchange = exchange.mutate()
+                .request(originalRequest -> originalRequest
+                        .headers(httpHeaders -> httpHeaders.set(requestIdName, requestId))
+                )
+                .build();
+        return chain.execute(modifiedExchange);
+    }
+
+    @Override
+    public int getOrder() {
+        return PluginEnum.REQUEST_ID.getCode();
+    }
+
+    @Override
+    public String named() {
+        return PluginEnum.REQUEST_ID.getName();
+    }
+}

--- a/shenyu-plugin/shenyu-plugin-request-id/src/test/java/org/apache/shenyu/plugin/request/id/RequestIdPluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-request-id/src/test/java/org/apache/shenyu/plugin/request/id/RequestIdPluginTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.request.id;
+
+import org.apache.shenyu.plugin.api.ShenyuPluginChain;
+import org.apache.shenyu.plugin.api.request.id.DefaultRequestIdGenerator;
+import org.apache.shenyu.plugin.api.request.id.RequestIdGenerator;
+import org.apache.shenyu.plugin.api.request.id.ShenyuRequestIdWrap;
+import org.apache.shenyu.plugin.api.utils.SpringBeanUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * The Test Case For RequestId plugin.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RequestIdPluginTest {
+
+    private RequestIdPlugin requestIdPlugin;
+
+    private ServerWebExchange exchange;
+
+    private ShenyuPluginChain chain;
+
+    @Before
+    public void setUp() {
+        this.requestIdPlugin = new RequestIdPlugin();
+        this.chain = mock(ShenyuPluginChain.class);
+        MockServerHttpRequest request = MockServerHttpRequest
+                .get("localhost")
+                .remoteAddress(new InetSocketAddress(8090))
+                .header("X-source", "mock test")
+                .queryParam("queryParam", "Hello,World")
+                .build();
+        this.exchange = spy(MockServerWebExchange.from(request));
+
+        ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+        SpringBeanUtils.getInstance().setApplicationContext(context);
+
+        when(context.getBean(RequestIdGenerator.class)).thenReturn(new DefaultRequestIdGenerator());
+    }
+
+    @Test
+    public void testDoExecute() {
+        this.requestIdPlugin.execute(this.exchange, this.chain);
+        assertNotNull(ShenyuRequestIdWrap.getRequestId());
+    }
+}

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/pom.xml
@@ -69,5 +69,13 @@
             <version>${project.version}</version>
         </dependency>
         <!--shenyu response plugin end-->
+
+        <!-- shenyu request id plugin start-->
+        <dependency>
+            <groupId>org.apache.shenyu</groupId>
+            <artifactId>shenyu-spring-boot-starter-plugin-request-id</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- shenyu request id plugin end-->
     </dependencies>
 </project>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml
@@ -57,5 +57,6 @@
         <module>shenyu-spring-boot-starter-plugin-param-mapping</module>
         <module>shenyu-spring-boot-starter-plugin-cryptor</module>
         <module>shenyu-spring-boot-starter-plugin-websocket</module>
+        <module>shenyu-spring-boot-starter-plugin-request-id</module>
     </modules>
 </project>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request-id/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request-id/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
+        <groupId>org.apache.shenyu</groupId>
+        <version>2.4.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shenyu-spring-boot-starter-plugin-request-id</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shenyu</groupId>
+            <artifactId>shenyu-plugin-request-id</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request-id/src/main/java/org/apache/shenyu/springboot/starter/plugin/request/id/RequestIdPluginConfiguration.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request-id/src/main/java/org/apache/shenyu/springboot/starter/plugin/request/id/RequestIdPluginConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.springboot.starter.plugin.request.id;
+
+import org.apache.shenyu.plugin.request.id.RequestIdPlugin;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * the request id plugin configuration.
+ */
+@Configuration
+public class RequestIdPluginConfiguration {
+
+    /**
+     * Export the request id plugin.
+     *
+     * @return the request id plugin.
+     */
+    @Bean
+    public RequestIdPlugin requestIdPlugin() {
+        return new RequestIdPlugin();
+    }
+}

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request-id/src/main/resources/META-INF/spring.factories
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request-id/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.apache.shenyu.springboot.starter.plugin.request.id.RequestIdPluginConfiguration

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request-id/src/main/resources/META-INF/spring.provides
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request-id/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+provides: shenyu-spring-boot-starter-plugin-request-id

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request-id/src/test/java/org/apache/shenyu/springboot/starter/plugin/request/id/RequestIdPluginConfigurationTest.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request-id/src/test/java/org/apache/shenyu/springboot/starter/plugin/request/id/RequestIdPluginConfigurationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.springboot.starter.plugin.request.id;
+
+import org.apache.shenyu.common.enums.PluginEnum;
+import org.apache.shenyu.plugin.api.ShenyuPlugin;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.http.codec.support.DefaultServerCodecConfigurer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The test for RequestIdPluginConfiguration.
+ */
+public class RequestIdPluginConfigurationTest {
+
+    @Test
+    public void testLoggingPlugin() {
+        new ApplicationContextRunner()
+                .withConfiguration(
+                        AutoConfigurations.of(
+                                RequestIdPluginConfiguration.class
+                        ))
+                .withBean(DefaultServerCodecConfigurer.class)
+                .withPropertyValues("debug=true")
+                .run(context -> {
+                    ShenyuPlugin plugin = context.getBean("requestIdPlugin", ShenyuPlugin.class);
+                    assertThat(plugin.named()).isEqualTo(PluginEnum.REQUEST_ID.getName());
+                });
+    }
+}

--- a/shenyu-web/pom.xml
+++ b/shenyu-web/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>shenyu-spring-boot-starter-plugin-global</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.shenyu</groupId>
+            <artifactId>shenyu-spring-boot-starter-plugin-request-id</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         
         <dependency>
             <groupId>org.apache.shenyu</groupId>

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/configuration/ShenyuExtConfiguration.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/configuration/ShenyuExtConfiguration.java
@@ -18,6 +18,8 @@
 package org.apache.shenyu.web.configuration;
 
 import org.apache.shenyu.plugin.api.RemoteAddressResolver;
+import org.apache.shenyu.plugin.api.request.id.DefaultRequestIdGenerator;
+import org.apache.shenyu.plugin.api.request.id.RequestIdGenerator;
 import org.apache.shenyu.plugin.api.result.DefaultShenyuResult;
 import org.apache.shenyu.plugin.api.result.ShenyuResult;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -40,6 +42,17 @@ public class ShenyuExtConfiguration {
     @ConditionalOnMissingBean(value = ShenyuResult.class, search = SearchStrategy.ALL)
     public ShenyuResult<?> shenyuResult() {
         return new DefaultShenyuResult();
+    }
+
+    /**
+     * Shenyu request id generator.
+     *
+     * @return the shenyu request id generator
+     */
+    @Bean
+    @ConditionalOnMissingBean(value = RequestIdGenerator.class, search = SearchStrategy.ALL)
+    public RequestIdGenerator shenyuRequestIdGenerator() {
+        return new DefaultRequestIdGenerator();
     }
 
     /**


### PR DESCRIPTION
# Intro
- Generate  `request id` for every request, and put to the request header. the downstream can fetch `request id` from `request header`.
  > ### the `request id plugin` is the highest sort than others.


# Custom generator
implement the `org.apache.shenyu.plugin.api.request.id.RequestIdGenerator` and put to `spring ioc` can custom `request id generator`, default is `uuid`.

Use the `org.apache.shenyu.plugin.api.request.id.ShenyuRequestIdWrap#getRequestId` API at any time to get the `request id` anywhere in the application.