### PR TITLE
[type: refactor]Provide "ThreadShareUtils" and reset plugin default order.

### DIFF
--- a/shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java
@@ -28,148 +28,147 @@ public enum PluginEnum {
     /**
      * Global plugin enum.
      */
-    GLOBAL(1, 0, "global"),
+    GLOBAL(10, 0, "global"),
 
     /**
      * Sign plugin enum.
      */
-    SIGN(2, 0, "sign"),
+    SIGN(20, 0, "sign"),
 
     /**
      * Jwt plugin enum.
      */
-    JWT(9, 0, "jwt"),
+    JWT(30, 0, "jwt"),
 
     /**
      * OAuth2 plugin enum.
      */
-    OAUTH2(3, 0, "oauth2"),
+    OAUTH2(40, 0, "oauth2"),
 
     /**
      * Waf plugin enum.
      */
-    WAF(10, 0, "waf"),
+    WAF(50, 0, "waf"),
 
     /**
      * Rate limiter plugin enum.
      */
-    RATE_LIMITER(20, 0, "rate_limiter"),
+    RATE_LIMITER(60, 0, "rate_limiter"),
 
     /**
      * Param mapping plugin enum.
      */
-    PARAM_MAPPING(22, 0, "param_mapping"),
+    PARAM_MAPPING(70, 0, "param_mapping"),
 
     /**
      * Context path plugin enum.
      */
-    CONTEXT_PATH(25, 0, "context_path"),
+    CONTEXT_PATH(80, 0, "context_path"),
 
     /**
      * Rewrite plugin enum.
      */
-    REWRITE(30, 0, "rewrite"),
+    REWRITE(90, 0, "rewrite"),
 
     /**
      * Cryptor request plugin enum.
      */
-    CRYPTOR_REQUEST(30, 0, "cryptor_request"),
+    CRYPTOR_REQUEST(100, 0, "cryptor_request"),
 
     /**
      * Redirect plugin enum.
      */
-    REDIRECT(40, 0, "redirect"),
+    REDIRECT(110, 0, "redirect"),
 
     /**
      * Request plugin enum.
      */
-    REQUEST(42, 0, "request"),
+    REQUEST(120, 0, "request"),
 
     /**
      * ModifyResponse plugin enum.
      */
-    MODIFY_RESPONSE(44, 0, "modifyResponse"),
+    MODIFY_RESPONSE(130, 0, "modifyResponse"),
 
     /**
      * Hystrix plugin enum.
      */
-    HYSTRIX(45, 0, "hystrix"),
+    HYSTRIX(140, 0, "hystrix"),
 
     /**
      * Sentinel plugin enum.
      */
-    SENTINEL(45, 0, "sentinel"),
+    SENTINEL(150, 0, "sentinel"),
 
     /**
      * Resilence4J plugin enum.
      */
-    RESILIENCE4J(45, 0, "resilience4j"),
+    RESILIENCE4J(160, 0, "resilience4j"),
 
     /**
      * Logging plugin enum.
      */
-    LOGGING(45, 0, "logging"),
+    LOGGING(170, 0, "logging"),
 
     /**
      * Divide plugin enum.
      */
-    DIVIDE(50, 0, "divide"),
+    DIVIDE(180, 0, "divide"),
 
     /**
      * springCloud plugin enum.
      */
-    SPRING_CLOUD(50, 0, "springCloud"),
+    SPRING_CLOUD(190, 0, "springCloud"),
 
     /**
      * webSocket plugin enum.
      */
-    WEB_SOCKET(55, 0, "websocket"),
+    WEB_SOCKET(200, 0, "websocket"),
 
     /**
      * Param transform plugin enum.
      */
-    PARAM_TRANSFORM(58, 0, "paramTransform"),
+    PARAM_TRANSFORM(210, 0, "paramTransform"),
 
     /**
      * Dubbo plugin enum.
      */
-    DUBBO(60, 0, "dubbo"),
+    DUBBO(220, 0, "dubbo"),
 
     /**
      * Sofa plugin enum.
      */
-    SOFA(60, 0, "sofa"),
+    SOFA(230, 0, "sofa"),
 
     /**
      * Tars plugin enum.
      */
-    TARS(60, 0, "tars"),
+    TARS(240, 0, "tars"),
 
     /**
      * GPRC plugin enum.
      */
-    GRPC(60, 0, "grpc"),
+    GRPC(250, 0, "grpc"),
 
     /**
      * Motan plugin enum.
      */
-    MOTAN(60, 0, "motan"),
+    MOTAN(260, 0, "motan"),
 
     /**
      * Monitor plugin enum.
      */
-    MONITOR(80, 0, "monitor"),
+    MONITOR(270, 0, "monitor"),
 
     /**
      * Cryptor response plugin enum.
      */
-    CRYPTOR_RESPONSE(99, 0, "cryptor_response"),
+    CRYPTOR_RESPONSE(280, 0, "cryptor_response"),
 
     /**
      * Response plugin enum.
      */
-    RESPONSE(100, 0, "response");
-
+    RESPONSE(290, 0, "response");
 
     private final int code;
 

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/utils/ThreadShare.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/utils/ThreadShare.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.common.utils;
+
+import java.util.Objects;
+
+/**
+ * the thread share.
+ */
+public class ThreadShare<T> extends ThreadLocal<T> {
+
+    /**
+     * share thread.
+     */
+    private final Thread thread = Thread.currentThread();
+
+    /**
+     * the name.
+     */
+    private final String name;
+
+    public ThreadShare() {
+        this.name = "default-share";
+    }
+
+    /**
+     * create thread share by name.
+     *
+     * @param name the name
+     */
+    public ThreadShare(final String name) {
+        this.name = name;
+    }
+
+    /**
+     * create the share by name.
+     *
+     * @param name the name
+     * @param <T> the type
+     * @return thread share object
+     */
+    public static <T> ThreadShare<T> create(final String name) {
+        return new ThreadShare<>(name);
+    }
+
+    /**
+     * get and remove the shared data.
+     *
+     * @return the stored data
+     */
+    public T getRemove() {
+        try {
+            return this.get();
+        } finally {
+            this.remove();
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ThreadShare<?> that = (ThreadShare<?>) o;
+        return Objects.equals(thread, that.thread)
+                && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(thread, name);
+    }
+}

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/utils/ThreadShareUtils.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/utils/ThreadShareUtils.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.common.utils;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * the thread share utils.
+ */
+public final class ThreadShareUtils {
+
+    /**
+     * the default share.
+     */
+    private static final String DEFAULT_SHARE = "default-thread-share";
+
+    /**
+     * the thread share map.
+     */
+    private static final Map<ThreadShare<Object>, Object> SHARE_MAPPING = new ConcurrentHashMap<>();
+
+    /**
+     * get a static instance by name.
+     *
+     * @param name the name
+     * @return static instance
+     */
+    private static ThreadShare<Object> getShareByName(final String name) {
+        return new ThreadShare<>(name);
+    }
+
+    /**
+     * put data to thread share.
+     *
+     * @param data the data
+     * @param <T> the data type
+     */
+    public static <T> void put(final T data) {
+        put(DEFAULT_SHARE, data);
+    }
+
+    /**
+     * put the data to thread share.
+     *
+     * @param name the name
+     * @param data the data
+     * @param <T> the data type
+     */
+    public static <T> void put(final String name, final T data) {
+        SHARE_MAPPING.put(getShareByName(name), data);
+    }
+
+    /**
+     * get the thread shared data.
+     *
+     * @param <T> the data type
+     * @return the data
+     */
+    public static <T> T get() {
+        return get(DEFAULT_SHARE);
+    }
+
+    /**
+     * get share data.
+     *
+     * @param name the name
+     * @param <T> the data type
+     * @return the data
+     */
+    public static <T> T get(final String name) {
+        final ThreadShare<Object> share = getShareByName(name);
+        if (!SHARE_MAPPING.containsKey(share)) {
+            return null;
+        }
+        final Object data = SHARE_MAPPING.get(share);
+        return (T) data;
+    }
+
+    /**
+     * get and remove the thread shared data.
+     *
+     * @param <T> the data type
+     * @return the data
+     */
+    public static <T> T getRemove() {
+        return getRemove(DEFAULT_SHARE);
+    }
+
+    /**
+     * get and remove the thread shared data.
+     *
+     * @param name the name
+     * @param <T> the data type
+     * @return the data
+     */
+    public static <T> T getRemove(final String name) {
+        final ThreadShare<Object> share = getShareByName(name);
+        if (!SHARE_MAPPING.containsKey(share)) {
+            return null;
+        }
+        final Object data = SHARE_MAPPING.remove(share);
+        return (T) data;
+    }
+}

--- a/shenyu-plugin/shenyu-plugin-global/src/test/java/org/apache/shenyu/plugin/global/GlobalPluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-global/src/test/java/org/apache/shenyu/plugin/global/GlobalPluginTest.java
@@ -82,7 +82,7 @@ public final class GlobalPluginTest {
 
     @Test
     public void testGetOrder() {
-        assertEquals(globalPlugin.getOrder(), 1);
+        assertEquals(globalPlugin.getOrder(), 10);
     }
 
     @Test

--- a/shenyu-plugin/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/service/DefaultSignService.java
+++ b/shenyu-plugin/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/service/DefaultSignService.java
@@ -128,10 +128,10 @@ public class DefaultSignService implements SignService {
         return Pair.of(Boolean.TRUE, "");
     }
 
-    private Map<String, String> buildParamsMap(final ShenyuContext dto) {
+    private Map<String, String> buildParamsMap(final ShenyuContext shenyuContext) {
         Map<String, String> map = Maps.newHashMapWithExpectedSize(3);
-        map.put(Constants.TIMESTAMP, dto.getTimestamp());
-        map.put(Constants.PATH, dto.getPath());
+        map.put(Constants.TIMESTAMP, shenyuContext.getTimestamp());
+        map.put(Constants.PATH, shenyuContext.getPath());
         map.put(Constants.VERSION, "1.0.0");
         return map;
     }

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/handler/GlobalErrorHandler.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/handler/GlobalErrorHandler.java
@@ -18,6 +18,7 @@
 package org.apache.shenyu.web.handler;
 
 import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.shenyu.common.utils.ThreadShare;
 import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,7 @@ public class GlobalErrorHandler extends DefaultErrorWebExceptionHandler {
     /**
      * the http status holder.
      */
-    private static final ThreadLocal<Integer> HTTP_STATUS_HOLDER = new ThreadLocal<>();
+    private static final ThreadShare<Integer> HTTP_STATUS_HOLDER = new ThreadShare<>();
 
     /**
      * Instantiates a new Global error handler.
@@ -79,12 +80,8 @@ public class GlobalErrorHandler extends DefaultErrorWebExceptionHandler {
 
     @Override
     protected int getHttpStatus(final Map<String, Object> errorAttributes) {
-        try {
-            Integer status = HTTP_STATUS_HOLDER.get();
-            return Objects.nonNull(status) ? status : HttpStatus.INTERNAL_SERVER_ERROR.value();
-        } finally {
-            HTTP_STATUS_HOLDER.remove();
-        }
+        Integer status = HTTP_STATUS_HOLDER.getRemove();
+        return Objects.nonNull(status) ? status : HttpStatus.INTERNAL_SERVER_ERROR.value();
     }
 
     private Map<String, Object> response(final ServerRequest request) {

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/logo/ShenyuLogo.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/logo/ShenyuLogo.java
@@ -31,7 +31,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * the shenyu logo.
  */
 @Order(LoggingApplicationListener.DEFAULT_ORDER + 1)
-
 public class ShenyuLogo implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
     /**
      * logger.


### PR DESCRIPTION
Provide `ThreadShareUtils`. 

the `ThreadShareUtils` can share data for the same thread with a different name and two different threads with the same name.

the `ThreadShare` is a subclass for `ThreadLocal` and provides the `getRemove` function that does `get` and `remove` same time.

reset the plugin order, spaced by ten. `shenyu` users can insert the custom plugin between `shenyu` plugin a and `shenyu` another plugin b.