### PR TITLE
fix default fallback controller handler by "ShenyuResultWrap".

### DIFF
--- a/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
@@ -17,8 +17,8 @@
 
 package org.apache.shenyu.web.fallback;
 
-import org.apache.shenyu.plugin.api.result.DefaultShenyuEntity;
 import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
+import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,7 +44,7 @@ public class DefaultFallbackController {
     @GetMapping("/hystrix")
     public Object hystrixPluginFallback() {
         LOG.error("the default fallback for hystrix");
-        return DefaultShenyuEntity.error(ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getMsg(), null);
+        return ShenyuResultWrap.error(ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getMsg(), null);
     }
 
     /**
@@ -55,6 +55,6 @@ public class DefaultFallbackController {
     @GetMapping("/resilience4j")
     public Object resilience4jFallBack() {
         LOG.error("the default fallback for resilience4j");
-        return DefaultShenyuEntity.error(ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getMsg(), null);
+        return ShenyuResultWrap.error(ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getMsg(), null);
     }
 }

--- a/shenyu-web/src/test/java/org/apache/shenyu/web/fallback/DefaultFallbackControllerTest.java
+++ b/shenyu-web/src/test/java/org/apache/shenyu/web/fallback/DefaultFallbackControllerTest.java
@@ -17,17 +17,23 @@
 
 package org.apache.shenyu.web.fallback;
 
+import org.apache.shenyu.plugin.api.result.DefaultShenyuResult;
+import org.apache.shenyu.plugin.api.result.ShenyuResult;
 import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
+import org.apache.shenyu.plugin.api.utils.SpringBeanUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -44,6 +50,10 @@ public final class DefaultFallbackControllerTest {
 
     @Before
     public void setUp() {
+        ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+        SpringBeanUtils.getInstance().setApplicationContext(context);
+        when(context.getBean(ShenyuResult.class)).thenReturn(new DefaultShenyuResult() { });
+
         this.mockMvc = MockMvcBuilders.standaloneSetup(defaultFallbackController).build();
     }
 


### PR DESCRIPTION
the default fallback `DefaultFallbackController` uses the`DefaultShenyuEntity` that can not use custom `ShenyuResult`.  fixed it by `ShenyuResultWrap`.