### PR TITLE
fix "modify response" plugin order bug and optimize the "clientResponse"

### DIFF
--- a/shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java
@@ -88,27 +88,27 @@ public enum PluginEnum {
     /**
      * Hystrix plugin enum.
      */
-    HYSTRIX(140, 0, "hystrix"),
+    HYSTRIX(130, 0, "hystrix"),
     
     /**
      * Sentinel plugin enum.
      */
-    SENTINEL(150, 0, "sentinel"),
+    SENTINEL(140, 0, "sentinel"),
     
     /**
      * Resilence4J plugin enum.
      */
-    RESILIENCE4J(160, 0, "resilience4j"),
+    RESILIENCE4J(150, 0, "resilience4j"),
     
     /**
      * Logging plugin enum.
      */
-    LOGGING(170, 0, "logging"),
+    LOGGING(160, 0, "logging"),
     
     /**
      * Monitor plugin enum.
      */
-    MONITOR(180, 0, "monitor"),
+    MONITOR(170, 0, "monitor"),
     
     /**
      * Divide plugin enum.
@@ -134,6 +134,11 @@ public enum PluginEnum {
      * Netty http client plugin enum.
      */
     NETTY_HTTP_CLIENT(210, 0, "nettyHttpClient"),
+
+    /**
+     * ModifyResponse plugin enum.
+     */
+    MODIFY_RESPONSE(220, 0, "modifyResponse"),
     
     /**
      * Param transform plugin enum.
@@ -173,12 +178,7 @@ public enum PluginEnum {
     /**
      * Response plugin enum.
      */
-    RESPONSE(420, 0, "response"),
-    
-    /**
-     * ModifyResponse plugin enum.
-     */
-    MODIFY_RESPONSE(430, 0, "modifyResponse");
+    RESPONSE(420, 0, "response");
 
     private final int code;
 

--- a/shenyu-plugin/shenyu-plugin-modify-response/src/main/java/org/apache/shenyu/plugin/modify/response/ModifyResponsePlugin.java
+++ b/shenyu-plugin/shenyu-plugin-modify-response/src/main/java/org/apache/shenyu/plugin/modify/response/ModifyResponsePlugin.java
@@ -62,9 +62,6 @@ public class ModifyResponsePlugin extends AbstractShenyuPlugin {
     
     @Override
     protected Mono<Void> doExecute(final ServerWebExchange exchange, final ShenyuPluginChain chain, final SelectorData selector, final RuleData rule) {
-        if (Objects.isNull(rule)) {
-            return Mono.empty();
-        }
         final ShenyuContext shenyuContext = exchange.getAttribute(Constants.CONTEXT);
         assert shenyuContext != null;
         final ModifyResponseRuleHandle modifyResponseRuleHandle = ModifyResponsePluginDataHandler.CACHED_HANDLE.get().obtainHandle(CacheKeyUtils.INST.getKey(rule));


### PR DESCRIPTION
the `modify response` order must be before the `response` plugin.

the `clientResponse` should be using `exchange.getAttribute(Constants.CLIENT_RESPONSE_ATTR)`. and the `modify response` plugin must be executed after `httpclient` plugin.