### PR TITLE
fix "GlobalErrorHandler" error object to map bug by JacksonUtils.toMap.

### DIFF
--- a/shenyu-common/src/main/java/org/apache/shenyu/common/utils/JsonUtils.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/utils/JsonUtils.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.type.MapType;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
@@ -38,6 +39,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -83,6 +85,23 @@ public final class JsonUtils {
         } catch (IOException e) {
             LOG.warn("write to json string error: " + object, e);
             return "{}";
+        }
+    }
+
+    /**
+     * Object to Map.
+     *
+     * @param object the object
+     * @return the converted map
+     */
+    public static Map<String, Object> toMap(final Object object) {
+        try {
+            String json = MAPPER.writeValueAsString(object);
+            final MapType mapType = MAPPER.getTypeFactory().constructMapType(LinkedHashMap.class, String.class, Object.class);
+            return MAPPER.readValue(json, mapType);
+        } catch (IOException e) {
+            LOG.warn("write to map error: " + object, e);
+            return new LinkedHashMap<>();
         }
     }
 

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/handler/GlobalErrorHandler.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/handler/GlobalErrorHandler.java
@@ -17,7 +17,7 @@
 
 package org.apache.shenyu.web.handler;
 
-import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.shenyu.common.utils.JsonUtils;
 import org.apache.shenyu.common.utils.ThreadShare;
 import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
 import org.slf4j.Logger;
@@ -92,7 +92,7 @@ public class GlobalErrorHandler extends DefaultErrorWebExceptionHandler {
         }
         HTTP_STATUS_HOLDER.set(httpStatus.value());
         Object error = ShenyuResultWrap.error(httpStatus.value(), httpStatus.getReasonPhrase(), ex.getMessage());
-        return GsonUtils.getInstance().toObjectMap(GsonUtils.getInstance().toJson(error));
+        return JsonUtils.toMap(error);
     }
 
     private void logError(final ServerRequest request) {

--- a/shenyu-web/src/test/java/org/apache/shenyu/web/handler/GlobalErrorHandlerTest.java
+++ b/shenyu-web/src/test/java/org/apache/shenyu/web/handler/GlobalErrorHandlerTest.java
@@ -113,7 +113,7 @@ public class GlobalErrorHandlerTest {
                 .build();
         Map<String, Object> response = globalErrorHandler.getErrorAttributes(serverRequest, false);
         assertNotNull(response);
-        assertThat(response, hasEntry("code", 500L));
+        assertThat(response, hasEntry("code", 500));
         assertThat(response, hasEntry("message", HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase()));
         assertThat(response, hasEntry("data", nullPointerException.getMessage()));
     }


### PR DESCRIPTION
fix "GlobalErrorHandler" error object to map bug by JacksonUtils.toMap.

when the "error" is complex, Gson will parse the "complex" to `Gson JsonObject`, but Spring Boot uses `jaskson` which can not process the `Gson JsonObject`.