### PR TITLE
版本V2.4.0  Bugfix: 修复monitor组件由于度量指标未注册导致的NullPoint异常

### DIFF
--- a/shenyu-metrics/shenyu-metrics-spi/src/main/java/org/apache/shenyu/metrics/reporter/MetricsReporter.java
+++ b/shenyu-metrics/shenyu-metrics-spi/src/main/java/org/apache/shenyu/metrics/reporter/MetricsReporter.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.metrics.reporter;
 
+import org.apache.shenyu.metrics.constant.LabelNames;
 import org.apache.shenyu.metrics.entity.Metric;
 import org.apache.shenyu.metrics.spi.MetricsRegister;
 
@@ -38,8 +39,14 @@ public final class MetricsReporter {
      */
     public static void register(final MetricsRegister metricsRegister) {
         MetricsReporter.metricsRegister = metricsRegister;
+        registDefaultMetrics();
     }
-    
+
+    protected static void registDefaultMetrics() {
+        registerCounter(LabelNames.REQUEST_TOTAL, "shenyu request total count");
+        registerCounter(LabelNames.HTTP_REQUEST_TOTAL, new String[]{"path", "type"}, "shenyu http request type total count");
+        registerHistogram(LabelNames.EXECUTE_LATENCY_NAME, "the shenyu executor latency millis");
+    }
     /**
      * Register metrics.
      *


### PR DESCRIPTION
原因:org.apache.shenyu.plugin.monitor.MonitorPlugin下static代码段中注册了度量名称, 但其注册时机不对, MonitorPlugin加载时MetricsReporter@metricsRegister尚未注入或注入后可以被插件替换
从而导致MonitorPlugin插件运行时MetricsReporter.counterIncrement(LabelNames.REQUEST_TOTAL);(line:50)代码最终会报出org.apache.shenyu.metrics.prometheus.register.PrometheusMetricsRegister.counterIncrement() line:82会报NullPointException

修复方式: org.apache.shenyu.metrics.reporter.MetricsReporter@register(final MetricsRegister metricsRegister)中每次重新注册度量服务时会重新注册MonitorPlugin下static代码段中定义的指标

// Describe your PR here; eg. Fixes #issueNo

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
