### PR TITLE
thread safe fix

### DIFF
--- a/shenyu-metrics/shenyu-metrics-prometheus/src/main/java/org/apache/shenyu/metrics/prometheus/register/PrometheusMetricsRegister.java
+++ b/shenyu-metrics/shenyu-metrics-prometheus/src/main/java/org/apache/shenyu/metrics/prometheus/register/PrometheusMetricsRegister.java
@@ -45,7 +45,7 @@ public final class PrometheusMetricsRegister implements MetricsRegister {
             if (null != labelNames) {
                 builder.labelNames(labelNames);
             }
-            COUNTER_MAP.put(name, builder.register());
+            COUNTER_MAP.putIfAbsent(name, builder.register());
         }
     }
     
@@ -56,7 +56,7 @@ public final class PrometheusMetricsRegister implements MetricsRegister {
             if (null != labelNames) {
                 builder.labelNames(labelNames);
             }
-            GAUGE_MAP.put(name, builder.register());
+            GAUGE_MAP.putIfAbsent(name, builder.register());
         }
     }
     
@@ -67,7 +67,7 @@ public final class PrometheusMetricsRegister implements MetricsRegister {
             if (null != labelNames) {
                 builder.labelNames(labelNames);
             }
-            HISTOGRAM_MAP.put(name, builder.register());
+            HISTOGRAM_MAP.putIfAbsent(name, builder.register());
         }
     }
     


### PR DESCRIPTION
My PR is about fixing thread-safety about ConcurrentHashMap usage.
The reports are automatically generated by Amazon AWS CodeGuru Reviewer.
The problem:
Usage of containsKey() and put() may not be thread-safe at lines: 54 and 59. Two threads can perform this same check at the same time and one thread can overwrite the value written by the other thread.
My potential solution:
Using putIfAbsent() to replace put(), by the logic of original code, the put should not be called again to update the existing key, so using putIfAbsent will automatically stop the operation if any thread put things first.


