### PR TITLE
[type: bug] fix zk sync error handling event bug.

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataService.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataService.java
@@ -189,7 +189,6 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
                             cacheSelectorData(selectorData);
                             return realPath;
                         }).forEach(this::subscribeSelectorDataChanges);
-
                     }
                 });
                 break;
@@ -267,7 +266,8 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         zkClient.subscribeDataChanges(path, new IZkDataListener() {
             @Override
             public void handleDataChange(final String dataPath, final Object data) {
-                cacheSelectorData(GsonUtils.getInstance().fromJson(data.toString(), SelectorData.class));
+                Optional.ofNullable(data)
+                        .ifPresent(e -> cacheSelectorData(GsonUtils.getInstance().fromJson(data.toString(), SelectorData.class)));
             }
 
             @Override
@@ -281,7 +281,8 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         zkClient.subscribeDataChanges(path, new IZkDataListener() {
             @Override
             public void handleDataChange(final String dataPath, final Object data) {
-                cacheRuleData(GsonUtils.getInstance().fromJson(data.toString(), RuleData.class));
+                Optional.ofNullable(data)
+                        .ifPresent(e -> cacheRuleData(GsonUtils.getInstance().fromJson(data.toString(), RuleData.class)));
             }
 
             @Override
@@ -295,7 +296,8 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         zkClient.subscribeDataChanges(realPath, new IZkDataListener() {
             @Override
             public void handleDataChange(final String dataPath, final Object data) {
-                cacheAuthData(GsonUtils.getInstance().fromJson(data.toString(), AppAuthData.class));
+                Optional.ofNullable(data)
+                        .ifPresent(e -> cacheAuthData(GsonUtils.getInstance().fromJson(data.toString(), AppAuthData.class)));
             }
 
             @Override
@@ -309,7 +311,8 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         zkClient.subscribeDataChanges(realPath, new IZkDataListener() {
             @Override
             public void handleDataChange(final String dataPath, final Object data) {
-                cacheMetaData(GsonUtils.getInstance().fromJson(data.toString(), MetaData.class));
+                Optional.ofNullable(data)
+                        .ifPresent(e -> cacheMetaData(GsonUtils.getInstance().fromJson(data.toString(), MetaData.class)));
             }
 
             @Override


### PR DESCRIPTION
fix bug
`2021-11-17 22:29:54 [ZkClient-EventThread-53-10.255.198.19:2181,10.255.198.16:2181,10.255.198.6:2181] ERROR org.I0Itec.zkclient.ZkEventThread - Error handling event ZkEvent[Data of /shenyu/selector/contextPath/1460961927473303552 changed sent to org.apache.shenyu.sync.data.zookeeper.ZookeeperSyncDataService$2@3d196372]
java.lang.NullPointerException: null
	at org.apache.shenyu.sync.data.zookeeper.ZookeeperSyncDataService$2.handleDataChange(ZookeeperSyncDataService.java:271)
	at org.I0Itec.zkclient.ZkClient$9.run(ZkClient.java:823)
	at org.I0Itec.zkclient.ZkEventThread.run(ZkEventThread.java:72)`