### PR TITLE
[type: refactor] ExcludeOperatorJudge

### DIFF
--- a/shenyu-common/src/test/java/org/apache/shenyu/common/utils/PathMatchUtilsTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/utils/PathMatchUtilsTest.java
@@ -42,5 +42,6 @@ public final class PathMatchUtilsTest {
         assertFalse(PathMatchUtils.match("test*aaa", "testblaaab"));
         // test matching with **'s
         assertTrue(PathMatchUtils.match("/**", "/testing/testing"));
+        assertTrue(PathMatchUtils.match("/test/**", "/test/test"));
     }
 }

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/condition/judge/ExcludeOperatorJudge.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/condition/judge/ExcludeOperatorJudge.java
@@ -18,6 +18,7 @@
 package org.apache.shenyu.plugin.base.condition.judge;
 
 import org.apache.shenyu.common.dto.ConditionData;
+import org.apache.shenyu.common.utils.PathMatchUtils;
 import org.apache.shenyu.spi.Join;
 
 import java.util.Objects;
@@ -30,6 +31,6 @@ public class ExcludeOperatorJudge implements PredicateJudge {
 
     @Override
     public Boolean judge(final ConditionData conditionData, final String realData) {
-        return !Objects.equals(realData, conditionData.getParamValue().trim());
+        return !PathMatchUtils.match(conditionData.getParamValue().trim(), realData);
     }
 }

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/condition/judge/ExcludeOperatorJudge.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/condition/judge/ExcludeOperatorJudge.java
@@ -21,8 +21,6 @@ import org.apache.shenyu.common.dto.ConditionData;
 import org.apache.shenyu.common.utils.PathMatchUtils;
 import org.apache.shenyu.spi.Join;
 
-import java.util.Objects;
-
 /**
  * Exclude predicate judge.
  */


### PR DESCRIPTION

When using the'exclude' function, users can use regular judgments, and use the 'excludePathPattern' of 'springBoot' close to the user Habit.

For example, use '/test/**' to filter the entire 'test' module.