### PR TITLE
[ISSUE #1824] shenyu-admin module test coverage improvement 

### DIFF
--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/disruptor/subscriber/MetadataExecutorSubscriberTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/disruptor/subscriber/MetadataExecutorSubscriberTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+    
+package org.apache.shenyu.admin.disruptor.subscriber;
+    
+import org.apache.shenyu.admin.service.register.ShenyuClientRegisterService;
+import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
+import org.apache.shenyu.register.common.type.DataType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+    
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+    
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+    
+/**
+ * Test cases for {@link MetadataExecutorSubscriber}.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class MetadataExecutorSubscriberTest {
+
+    @InjectMocks
+    private MetadataExecutorSubscriber metadataExecutorSubscriber;
+    
+    @Mock
+    private Map<String, ShenyuClientRegisterService> shenyuClientRegisterService;
+    
+    @Test
+    public void testGetType() {
+        assertEquals(DataType.META_DATA, metadataExecutorSubscriber.getType());
+    }
+    
+    @Test
+    public void testExecutor() {
+        List<MetaDataRegisterDTO> list = new ArrayList<>();
+        metadataExecutorSubscriber.executor(list);
+        assertEquals(true, list.isEmpty());
+        list.add(MetaDataRegisterDTO.builder().appName("test").build());
+        ShenyuClientRegisterService service = mock(ShenyuClientRegisterService.class);
+        when(shenyuClientRegisterService.get(any())).thenReturn(service);
+        metadataExecutorSubscriber.executor(list);
+        verify(service).register(any());
+    }
+}

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/disruptor/subscriber/URIRegisterExecutorSubscriberTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/disruptor/subscriber/URIRegisterExecutorSubscriberTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+    
+package org.apache.shenyu.admin.disruptor.subscriber;
+    
+import org.apache.shenyu.admin.service.register.ShenyuClientRegisterService;
+import org.apache.shenyu.common.exception.ShenyuException;
+import org.apache.shenyu.register.common.dto.URIRegisterDTO;
+import org.apache.shenyu.register.common.type.DataType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+    
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+    
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+    
+/**
+ * Test cases for {@link URIRegisterExecutorSubscriber}.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class URIRegisterExecutorSubscriberTest {
+    
+    @InjectMocks
+    private URIRegisterExecutorSubscriber uriRegisterExecutorSubscriber;
+    
+    @Mock
+    private Map<String, ShenyuClientRegisterService> shenyuClientRegisterService;
+    
+    @Test
+    public void testGetType() {
+        assertEquals(DataType.URI, uriRegisterExecutorSubscriber.getType());
+    }
+    
+    @Test
+    public void testExecutor() {
+        List<URIRegisterDTO> list = new ArrayList<>();
+        uriRegisterExecutorSubscriber.executor(list);
+        assertEquals(true, list.isEmpty());
+        list.add(URIRegisterDTO.builder().appName("test").contextPath("/test").build());
+        ShenyuClientRegisterService service = mock(ShenyuClientRegisterService.class);
+        when(shenyuClientRegisterService.get(any())).thenReturn(service);
+        uriRegisterExecutorSubscriber.executor(list);
+        verify(service).registerURI(any(), any());
+    }
+    
+    @Test
+    public void testBuildData() {
+        try {
+            List<URIRegisterDTO> list = new ArrayList<>();
+            list.add(URIRegisterDTO.builder().appName("test1").build());
+            list.add(URIRegisterDTO.builder().appName("test2").build());
+            Method testMethod = uriRegisterExecutorSubscriber.getClass().getDeclaredMethod("buildData", Collection.class);
+            testMethod.setAccessible(true);
+            Map<String, List<URIRegisterDTO>> result = (Map) testMethod.invoke(uriRegisterExecutorSubscriber, list);
+            assertEquals(2, result.size());
+            
+            list.add(URIRegisterDTO.builder().appName("test1").build());
+            result = (Map) testMethod.invoke(uriRegisterExecutorSubscriber, list);
+            assertEquals(2, result.size());
+        } catch (Exception e) {
+            throw new ShenyuException(e.getCause());
+        }
+    }
+    
+    @Test
+    public void testFindService() {
+        try {
+            List<URIRegisterDTO> list = new ArrayList<>();
+            list.add(URIRegisterDTO.builder().appName("test1").build());
+            list.add(URIRegisterDTO.builder().appName("test2").build());
+            ShenyuClientRegisterService service = mock(ShenyuClientRegisterService.class);
+            when(shenyuClientRegisterService.get(any())).thenReturn(service);
+            Method testMethod = uriRegisterExecutorSubscriber.getClass().getDeclaredMethod("findService", Collection.class);
+            testMethod.setAccessible(true);
+            Optional<ShenyuClientRegisterService> result = (Optional) testMethod.invoke(uriRegisterExecutorSubscriber, list);
+            assertEquals(service, result.get());
+        } catch (Exception e) {
+            throw new ShenyuException(e.getCause());
+        }
+    }
+}

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/bean/StatelessAuthFilterTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/bean/StatelessAuthFilterTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.admin.shiro.bean;
+
+import org.apache.shenyu.common.exception.ShenyuException;
+import org.apache.shiro.subject.Subject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpMethod;
+
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link StatelessAuthFilter}.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public final class StatelessAuthFilterTest {
+    
+    private static final String HEAD_TOKEN = "X-Access-Token";
+    
+    @InjectMocks
+    private StatelessAuthFilter statelessAuthFilter;
+    
+    @Mock
+    private HttpServletRequest httpServletRequest;
+    
+    @Mock
+    private HttpServletResponse httpServletResponse;
+    
+    @Test
+    public void testIsAccessAllowed() {
+        Object obj = mock(Object.class);
+        assertEquals(false, statelessAuthFilter.isAccessAllowed(httpServletRequest, httpServletResponse, obj));
+    }
+    
+    @Test(expected = ShenyuException.class)
+    public void testOnAccessDenied() {
+        StatelessToken token = mock(StatelessToken.class);
+        Subject subject = mock(Subject.class);
+        try {
+            when(httpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS.name());
+            assertEquals(true, statelessAuthFilter.onAccessDenied(httpServletRequest, httpServletResponse));
+
+            when(httpServletRequest.getHeader(HEAD_TOKEN)).thenReturn(null);
+            assertEquals(true, statelessAuthFilter.onAccessDenied(httpServletRequest, httpServletResponse));
+
+            doThrow(new Exception()).when(subject).login(token);
+            assertEquals(false, statelessAuthFilter.onAccessDenied(httpServletRequest, httpServletResponse));
+
+            assertEquals(true, statelessAuthFilter.onAccessDenied(httpServletRequest, httpServletResponse));
+        } catch (Exception e) {
+            throw new ShenyuException(e.getCause());
+        }
+    }
+    
+    @Test
+    public void testUnionFailResponse() {
+        PrintWriter printWriter = mock(PrintWriter.class);
+        try {
+            when(httpServletResponse.getWriter()).thenReturn(printWriter);
+            doNothing().when(printWriter).println();
+            Method testMethod = statelessAuthFilter.getClass().getDeclaredMethod("unionFailResponse", ServletResponse.class);
+            testMethod.setAccessible(true);
+            testMethod.invoke(statelessAuthFilter, httpServletResponse);
+            verify(httpServletResponse).setContentType("application/json;charset=utf-8");
+            verify(httpServletResponse).setCharacterEncoding("utf-8");
+            verify(httpServletResponse).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        } catch (Exception e) {
+            throw new ShenyuException(e.getCause());
+        }
+    }
+    
+    @Test
+    public void testWrapCorsResponse() {
+        try {
+            Method testMethod = statelessAuthFilter.getClass().getDeclaredMethod("wrapCorsResponse", HttpServletResponse.class);
+            testMethod.setAccessible(true);
+            testMethod.invoke(statelessAuthFilter, httpServletResponse);
+            verify(httpServletResponse).addHeader("Access-Control-Allow-Origin", "*");
+            verify(httpServletResponse).addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
+            verify(httpServletResponse).addHeader("Access-Control-Allow-Headers", "Content-Type");
+            verify(httpServletResponse).addHeader("Access-Control-Max-Age", "1800");
+        } catch (Exception e) {
+            throw new ShenyuException(e.getCause());
+        }
+    }
+}

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/bean/StatelessTokenTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/bean/StatelessTokenTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.admin.shiro.bean;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+/**
+ * Test cases for {@link StatelessToken}.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public final class StatelessTokenTest {
+    
+    private final String token = "token";
+    
+    private final StatelessToken statelessToken = new StatelessToken(token);
+    
+    @Test
+    public void testGetPrincipal() {
+        assertEquals(token,statelessToken.getPrincipal());
+    }
+
+    @Test
+    public void testGetCredentials() {
+        assertEquals(token,statelessToken.getCredentials());
+    }
+}

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/bean/StatelessTokenTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/bean/StatelessTokenTest.java
@@ -22,23 +22,24 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+    
 /**
  * Test cases for {@link StatelessToken}.
  */
 @RunWith(MockitoJUnitRunner.Silent.class)
 public final class StatelessTokenTest {
     
-    private final String token = "token";
+    private static final String TOKEN = "token";
     
-    private final StatelessToken statelessToken = new StatelessToken(token);
+    private final StatelessToken statelessToken = new StatelessToken(TOKEN);
     
     @Test
     public void testGetPrincipal() {
-        assertEquals(token,statelessToken.getPrincipal());
+        assertEquals(TOKEN, statelessToken.getPrincipal());
     }
-
+    
     @Test
     public void testGetCredentials() {
-        assertEquals(token,statelessToken.getCredentials());
+        assertEquals(TOKEN, statelessToken.getCredentials());
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroConfigurationTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroConfigurationTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.admin.shiro.config;
+
+import com.alibaba.nacos.common.utils.Objects;
+import org.apache.shenyu.admin.config.properties.ShiroProperties;
+import org.apache.shiro.realm.AuthorizingRealm;
+import org.apache.shiro.spring.LifecycleBeanPostProcessor;
+import org.apache.shiro.spring.security.interceptor.AuthorizationAttributeSourceAdvisor;
+import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
+import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link ShiroConfiguration}.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public final class ShiroConfigurationTest {
+    
+    @InjectMocks
+    private ShiroConfiguration shiroConfiguration;
+    
+    @Mock
+    private DefaultWebSecurityManager securityManager;
+    
+    @Test
+    public void testSecurityManager() {
+        AuthorizingRealm realm = mock(AuthorizingRealm.class);
+        DefaultWebSecurityManager securityManager = shiroConfiguration.securityManager(realm);
+        Object[] realms = securityManager.getRealms().toArray();
+        assertEquals(1, realms.length);
+        assert Objects.equals(realm, realms[0]);
+    }
+    
+    @Test
+    public void testShiroFilterFactoryBean() {
+        ShiroProperties shiroProperties = mock(ShiroProperties.class);
+        List<String> whiteList = Arrays.asList("test1", "test2");
+        when(shiroProperties.getWhiteList()).thenReturn(whiteList);
+        ShiroFilterFactoryBean shiroFilterFactoryBean = shiroConfiguration.shiroFilterFactoryBean(securityManager, shiroProperties);
+        assertEquals(securityManager, shiroFilterFactoryBean.getSecurityManager());
+        assertNotNull(shiroFilterFactoryBean.getFilters());
+        assertNotNull(shiroFilterFactoryBean.getFilters().get("statelessAuth"));
+        Map<String, String> map = shiroFilterFactoryBean.getFilterChainDefinitionMap();
+        assertNotNull(map);
+        whiteList.stream().forEach(s -> assertEquals("anon", map.get(s)));
+        assertEquals("statelessAuth", map.get("/**"));
+    }
+    
+    @Test
+    public void testAuthorizationAttributeSourceAdvisor() {
+        AuthorizationAttributeSourceAdvisor advisor = shiroConfiguration.authorizationAttributeSourceAdvisor(securityManager);
+        assertEquals(securityManager, advisor.getSecurityManager());
+    }
+    
+    @Test
+    public void testGetDefaultAdvisorAutoProxyCreator() {
+        DefaultAdvisorAutoProxyCreator creator = shiroConfiguration.getDefaultAdvisorAutoProxyCreator();
+        assertNotNull(creator);
+        assertEquals(true, creator.isProxyTargetClass());
+    }
+    
+    @Test
+    public void testLifecycleBeanPostProcessor() {
+        LifecycleBeanPostProcessor postProcessor = shiroConfiguration.lifecycleBeanPostProcessor();
+        assertNotNull(postProcessor);
+    }
+}

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroConfigurationTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroConfigurationTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shenyu.admin.shiro.config;
 
-import com.alibaba.nacos.common.utils.Objects;
 import org.apache.shenyu.admin.config.properties.ShiroProperties;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.spring.LifecycleBeanPostProcessor;
@@ -34,6 +33,7 @@ import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreato
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -96,26 +97,42 @@ public final class ShiroRealmTest {
         when(token.getCredentials()).thenReturn(null);
         assertNull(shiroRealm.doGetAuthenticationInfo(token));
 
-        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-                + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
-                + ".cThIIoDvwdueQB468K5xDc5633seEFoqwxjF_xSJyQQ");
-        exception.expect(AuthenticationException.class);
-        shiroRealm.doGetAuthenticationInfo(token);
-    
-        when(dashboardUserService.findByUserName(any())).thenReturn(null);
-        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-                + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
-                + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
-        exception.expect(AuthenticationException.class);
-        shiroRealm.doGetAuthenticationInfo(token);
-    
-        when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
-        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-                + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
-                + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
-        exception.expect(AuthenticationException.class);
-        shiroRealm.doGetAuthenticationInfo(token);
-    
+        boolean thrown = false;
+        try {
+            when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                    + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
+                    + ".cThIIoDvwdueQB468K5xDc5633seEFoqwxjF_xSJyQQ");
+            shiroRealm.doGetAuthenticationInfo(token);
+        }catch (AuthenticationException e){
+            thrown = true;
+        }
+       assertTrue(thrown);
+
+        try {
+            when(dashboardUserService.findByUserName(any())).thenReturn(null);
+            when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                    + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
+                    + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
+            shiroRealm.doGetAuthenticationInfo(token);
+        }catch (AuthenticationException e){
+            thrown = true;
+        }
+        assertTrue(thrown);
+
+        try {
+            when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
+            when(dashboardUserVO.getPassword()).thenReturn(PASSWORD);
+            when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                    + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
+                    + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
+            shiroRealm.doGetAuthenticationInfo(token);
+        }catch (AuthenticationException e){
+            thrown = true;
+        }catch (Exception e) {
+            e.printStackTrace();
+        }
+        assertTrue(thrown);
+        
         when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
         when(dashboardUserVO.getPassword()).thenReturn(PASSWORD);
         when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.admin.shiro.config;
+
+import org.apache.shenyu.admin.model.custom.UserInfo;
+import org.apache.shenyu.admin.model.vo.DashboardUserVO;
+import org.apache.shenyu.admin.service.DashboardUserService;
+import org.apache.shenyu.admin.service.PermissionService;
+import org.apache.shenyu.admin.shiro.bean.StatelessToken;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.SimpleAuthenticationInfo;
+import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Test cases for {@link ShiroRealm}.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public final class ShiroRealmTest {
+
+    private static final String PASSWORD = "Axmk89Li3Aji9e";
+    @InjectMocks
+    private ShiroRealm shiroRealm;
+    
+    @Mock
+    private PermissionService permissionService;
+
+    @Mock
+    private DashboardUserService dashboardUserService;
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+    
+    @Test
+    public void testSupports() {
+        StatelessToken token = mock(StatelessToken.class);
+        assertEquals(true,shiroRealm.supports(token));
+    }
+    
+    @Test
+    public void testDoGetAuthorizationInfo(){
+        PrincipalCollection principalCollection = mock(PrincipalCollection.class);
+        UserInfo userInfo = new UserInfo();
+        
+        Set<String> strings = new HashSet<>();
+        when(principalCollection.getPrimaryPrincipal()).thenReturn(userInfo);
+        when(permissionService.getAuthPermByUserName(any())).thenReturn(strings);
+        assertNull(shiroRealm.doGetAuthorizationInfo(principalCollection));
+
+        strings.add("test");
+        when(principalCollection.getPrimaryPrincipal()).thenReturn(userInfo);
+        when(permissionService.getAuthPermByUserName(any())).thenReturn(strings);
+        AuthorizationInfo info = shiroRealm.doGetAuthorizationInfo(principalCollection);
+        assertEquals(strings,info.getStringPermissions());
+    }
+    
+    @Test
+    public void testDoGetAuthenticationInfo() {
+
+        AuthenticationToken token = mock(AuthenticationToken.class);
+        DashboardUserVO dashboardUserVO = mock(DashboardUserVO.class);
+
+        when(token.getCredentials()).thenReturn(null);
+        assertNull(shiroRealm.doGetAuthenticationInfo(token));
+
+        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
+                + ".cThIIoDvwdueQB468K5xDc5633seEFoqwxjF_xSJyQQ");
+        exception.expect(AuthenticationException.class);
+        shiroRealm.doGetAuthenticationInfo(token);
+
+        when(dashboardUserService.findByUserName(any())).thenReturn(null);
+        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
+        exception.expect(AuthenticationException.class);
+        shiroRealm.doGetAuthenticationInfo(token);
+        
+        when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
+        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
+        exception.expect(AuthenticationException.class);
+        shiroRealm.doGetAuthenticationInfo(token);
+        
+        when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
+        when(dashboardUserVO.getPassword()).thenReturn("123456");
+        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.Qlpf6FdKAffgceukbi2BQYdPVf71d4Nwy0YQlkiTQFc");
+        AuthenticationInfo info = shiroRealm.doGetAuthenticationInfo(token);
+        assertNotNull(info);
+    }
+    
+    
+}

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
@@ -25,22 +25,19 @@ import org.apache.shenyu.admin.shiro.bean.StatelessToken;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
-import org.apache.shiro.authc.SimpleAuthenticationInfo;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.subject.PrincipalCollection;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
+    
 import java.util.HashSet;
 import java.util.Set;
-
+    
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -48,37 +45,34 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-
 /**
  * Test cases for {@link ShiroRealm}.
  */
 @RunWith(MockitoJUnitRunner.Silent.class)
 public final class ShiroRealmTest {
-
-    private static final String PASSWORD = "Axmk89Li3Aji9e";
+    
+    private static final String PASSWORD = "123456";
+    
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
     @InjectMocks
     private ShiroRealm shiroRealm;
-    
     @Mock
     private PermissionService permissionService;
-
     @Mock
     private DashboardUserService dashboardUserService;
 
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
-    
     @Test
     public void testSupports() {
         StatelessToken token = mock(StatelessToken.class);
-        assertEquals(true,shiroRealm.supports(token));
+        assertEquals(true, shiroRealm.supports(token));
     }
-    
+
     @Test
-    public void testDoGetAuthorizationInfo(){
+    public void testDoGetAuthorizationInfo() {
         PrincipalCollection principalCollection = mock(PrincipalCollection.class);
         UserInfo userInfo = new UserInfo();
-        
+
         Set<String> strings = new HashSet<>();
         when(principalCollection.getPrimaryPrincipal()).thenReturn(userInfo);
         when(permissionService.getAuthPermByUserName(any())).thenReturn(strings);
@@ -88,12 +82,11 @@ public final class ShiroRealmTest {
         when(principalCollection.getPrimaryPrincipal()).thenReturn(userInfo);
         when(permissionService.getAuthPermByUserName(any())).thenReturn(strings);
         AuthorizationInfo info = shiroRealm.doGetAuthorizationInfo(principalCollection);
-        assertEquals(strings,info.getStringPermissions());
+        assertEquals(strings, info.getStringPermissions());
     }
-    
+
     @Test
     public void testDoGetAuthenticationInfo() {
-
         AuthenticationToken token = mock(AuthenticationToken.class);
         DashboardUserVO dashboardUserVO = mock(DashboardUserVO.class);
 
@@ -105,23 +98,27 @@ public final class ShiroRealmTest {
                 + ".cThIIoDvwdueQB468K5xDc5633seEFoqwxjF_xSJyQQ");
         exception.expect(AuthenticationException.class);
         shiroRealm.doGetAuthenticationInfo(token);
-
+    
         when(dashboardUserService.findByUserName(any())).thenReturn(null);
-        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
+        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
+                + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
         exception.expect(AuthenticationException.class);
         shiroRealm.doGetAuthenticationInfo(token);
-        
+    
         when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
-        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
+        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
+                + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
         exception.expect(AuthenticationException.class);
         shiroRealm.doGetAuthenticationInfo(token);
-        
+    
         when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
-        when(dashboardUserVO.getPassword()).thenReturn("123456");
-        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.Qlpf6FdKAffgceukbi2BQYdPVf71d4Nwy0YQlkiTQFc");
+        when(dashboardUserVO.getPassword()).thenReturn(PASSWORD);
+        when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
+                + ".Qlpf6FdKAffgceukbi2BQYdPVf71d4Nwy0YQlkiTQFc");
         AuthenticationInfo info = shiroRealm.doGetAuthenticationInfo(token);
         assertNotNull(info);
     }
-    
-    
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
@@ -55,10 +55,13 @@ public final class ShiroRealmTest {
     
     @Rule
     public final ExpectedException exception = ExpectedException.none();
+    
     @InjectMocks
     private ShiroRealm shiroRealm;
+    
     @Mock
     private PermissionService permissionService;
+    
     @Mock
     private DashboardUserService dashboardUserService;
 
@@ -87,8 +90,8 @@ public final class ShiroRealmTest {
 
     @Test
     public void testDoGetAuthenticationInfo() {
-        AuthenticationToken token = mock(AuthenticationToken.class);
-        DashboardUserVO dashboardUserVO = mock(DashboardUserVO.class);
+        final AuthenticationToken token = mock(AuthenticationToken.class);
+        final DashboardUserVO dashboardUserVO = mock(DashboardUserVO.class);
 
         when(token.getCredentials()).thenReturn(null);
         assertNull(shiroRealm.doGetAuthenticationInfo(token));

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
@@ -106,7 +106,7 @@ public final class ShiroRealmTest {
         } catch (AuthenticationException e) {
             thrown = true;
         }
-       assertTrue(thrown);
+        assertTrue(thrown);
 
         try {
             when(dashboardUserService.findByUserName(any())).thenReturn(null);

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
@@ -103,7 +103,7 @@ public final class ShiroRealmTest {
                     + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
                     + ".cThIIoDvwdueQB468K5xDc5633seEFoqwxjF_xSJyQQ");
             shiroRealm.doGetAuthenticationInfo(token);
-        }catch (AuthenticationException e){
+        } catch (AuthenticationException e) {
             thrown = true;
         }
        assertTrue(thrown);
@@ -114,7 +114,7 @@ public final class ShiroRealmTest {
                     + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
                     + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
             shiroRealm.doGetAuthenticationInfo(token);
-        }catch (AuthenticationException e){
+        } catch (AuthenticationException e) {
             thrown = true;
         }
         assertTrue(thrown);
@@ -126,10 +126,8 @@ public final class ShiroRealmTest {
                     + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
                     + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
             shiroRealm.doGetAuthenticationInfo(token);
-        }catch (AuthenticationException e){
+        } catch (AuthenticationException e) {
             thrown = true;
-        }catch (Exception e) {
-            e.printStackTrace();
         }
         assertTrue(thrown);
         


### PR DESCRIPTION
About #1824
About #2420

 following classes test code coverage:
org.apache.shenyu.admin.shiro.bean.StatelessAuthFilter(6%)
org.apache.shenyu.admin.shiro.bean.StatelessToken(0%)
org.apache.shenyu.admin.shiro.config.ShiroRealm(0%)
org.apache.shenyu.admin.disruptor.subscriber.URIRegisterExecutorSubscriber(12%)
org.apache.shenyu.admin.disruptor.subscriber.MetadataExecutorSubscriber(60%)

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
