### PR TITLE
[type: Integration-Test] Simplify the integration test process

### DIFF
--- a/.github/workflows/integrated-test.yml
+++ b/.github/workflows/integrated-test.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Build with Maven
         if: env.SKIP_CI != 'true'
         run: ./mvnw -B clean install -Prelease,docker -Dmaven.javadoc.skip=true -Dmaven.test.skip=true
-      - name: Build examples
-        if: env.SKIP_CI != 'true'
-        run: ./mvnw -B clean install -DskipTests -f ./shenyu-examples/pom.xml -Pdocker
       - name: Build integrated tests
         if: env.SKIP_CI != 'true'
         run: ./mvnw -B clean install -Pit -DskipTests -f ./shenyu-integrated-test/pom.xml


### PR DESCRIPTION
Since #2393 added the `examples` module to parent pom, we can build `examples` with other module by `./mvnw -B clean install -Prelease,docker -Dmaven.javadoc.skip=true -Dmaven.test.skip=true` (Build with Maven).

But now the docker image of `examples` is build twice.