### PR TITLE
[ISSUE #2588] org.apache.shenyu.sync.data.etcd.EtcdClient method [getSubNodeKeyName] throw “StringIndexOutOfBoundsException”

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-etcd/src/main/java/org/apache/shenyu/sync/data/etcd/EtcdClient.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-etcd/src/main/java/org/apache/shenyu/sync/data/etcd/EtcdClient.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
@@ -107,10 +108,14 @@ public class EtcdClient {
         return keyValues.stream()
                 .map(e -> getSubNodeKeyName(prefix, e.getKey().toString(StandardCharsets.UTF_8), separator))
                 .distinct()
+                .filter(e -> Objects.nonNull(e))
                 .collect(Collectors.toList());
     }
 
     private String getSubNodeKeyName(final String prefix, final String fullPath, final String separator) {
+        if (prefix.length() > fullPath.length()) {
+            return null;
+        }
         String pathWithoutPrefix = fullPath.substring(prefix.length());
         return pathWithoutPrefix.contains(separator) ? pathWithoutPrefix.substring(1) : pathWithoutPrefix;
     }


### PR DESCRIPTION
org.apache.shenyu.sync.data.etcd.EtcdClient method [getSubNodeKeyName] throw “StringIndexOutOfBoundsException”

// Describe your PR here; eg. Fixes #issueNo
Add protection measures and return null.

Fixes #2588 

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
