### PR TITLE
Dubbo ReferenceConfig when removed from the cache, call ReferenceConfig destroy method.

### DIFF
--- a/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/cache/ApacheDubboConfigCache.java
+++ b/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/cache/ApacheDubboConfigCache.java
@@ -22,7 +22,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.RegistryConfig;
@@ -37,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -49,26 +47,21 @@ import java.util.concurrent.ExecutionException;
  * The type Application config cache.
  */
 public final class ApacheDubboConfigCache extends DubboConfigCache {
-    
+
     private static final Logger LOG = LoggerFactory.getLogger(ApacheDubboConfigCache.class);
-    
+
     private ApplicationConfig applicationConfig;
-    
+
     private RegistryConfig registryConfig;
-    
+
     private final LoadingCache<String, ReferenceConfig<GenericService>> cache = CacheBuilder.newBuilder()
             .maximumSize(Constants.CACHE_MAX_COUNT)
             .removalListener((RemovalListener<Object, ReferenceConfig<GenericService>>) notification -> {
                 ReferenceConfig<GenericService> config = notification.getValue();
                 if (Objects.nonNull(config)) {
-                    try {
-                        Field field = FieldUtils.getDeclaredField(config.getClass(), "ref", true);
-                        field.set(config, null);
-                        // After the configuration change, Dubbo destroys the instance, but does not empty it. If it is not handled,
-                        // it will get NULL when reinitializing and cause a NULL pointer problem.
-                    } catch (NullPointerException | IllegalAccessException e) {
-                        LOG.error("modify ref have exception", e);
-                    }
+                    // After the configuration change, Dubbo destroys the instance, but does not empty it. If it is not handled,
+                    // it will get NULL when reinitializing and cause a NULL pointer problem.
+                    config.destroy();
                 }
             })
             .build(new CacheLoader<String, ReferenceConfig<GenericService>>() {
@@ -78,8 +71,8 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
                     return new ReferenceConfig<>();
                 }
             });
-    
-    
+
+
     /**
      * Gets instance.
      *
@@ -88,7 +81,7 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
     public static ApacheDubboConfigCache getInstance() {
         return ApplicationConfigCacheInstance.INSTANCE;
     }
-    
+
     /**
      * Init.
      *
@@ -108,7 +101,7 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
             registryConfig = registryConfigTemp;
         }
     }
-    
+
     private boolean needUpdateRegistryConfig(final DubboRegisterConfig dubboRegisterConfig) {
         if (Objects.isNull(registryConfig)) {
             return true;
@@ -117,7 +110,7 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
                 || !Objects.equals(dubboRegisterConfig.getRegister(), registryConfig.getAddress())
                 || !Objects.equals(dubboRegisterConfig.getProtocol(), registryConfig.getProtocol());
     }
-    
+
     /**
      * Init ref reference config.
      *
@@ -135,7 +128,7 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
         }
         return build(metaData);
     }
-    
+
     /**
      * Build reference config.
      *
@@ -150,18 +143,18 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
         ReferenceConfig<GenericService> reference = new ReferenceConfig<>();
         reference.setGeneric("true");
         reference.setAsync(true);
-        
+
         reference.setApplication(applicationConfig);
         reference.setRegistry(registryConfig);
         reference.setInterface(metaData.getServiceName());
         reference.setProtocol("dubbo");
         reference.setCheck(false);
         reference.setLoadbalance("gray");
-        
+
         Map<String, String> parameters = new HashMap<>(2);
         parameters.put("dispatcher", "direct");
         reference.setParameters(parameters);
-        
+
         String rpcExt = metaData.getRpcExt();
         DubboParam dubboParam = parserToDubboParam(rpcExt);
         if (Objects.nonNull(dubboParam)) {
@@ -189,7 +182,7 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
         }
         return reference;
     }
-    
+
     /**
      * Get reference config.
      *
@@ -203,7 +196,7 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
             throw new ShenyuException(e.getCause());
         }
     }
-    
+
     /**
      * Invalidate.
      *
@@ -212,14 +205,14 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
     public void invalidate(final String path) {
         cache.invalidate(path);
     }
-    
+
     /**
      * Invalidate all.
      */
     public void invalidateAll() {
         cache.invalidateAll();
     }
-    
+
     /**
      * The type Application config cache instance.
      */
@@ -228,9 +221,9 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
          * The Instance.
          */
         static final ApacheDubboConfigCache INSTANCE = new ApacheDubboConfigCache();
-        
+
         private ApplicationConfigCacheInstance() {
-        
+
         }
     }
 }


### PR DESCRIPTION
Dubbo ReferenceConfig when removed from the cache, call ReferenceConfig destroy method.

// Describe your PR here; eg. Fixes #issueNo

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
