### PR TITLE
[type:refactor]Dubbo ReferenceConfig when removed from the cache, call ReferenceConfig destroy method.

### DIFF
--- a/shenyu-integrated-test/shenyu-integrated-test-https/script/services.list
+++ b/shenyu-integrated-test/shenyu-integrated-test-https/script/services.list
@@ -16,4 +16,4 @@
 
 http://localhost:9095/actuator/health
 http://localhost:9195/actuator/health
-http://localhost:8080/order/findById?id=3
+http://localhost:8080/actuator/health

--- a/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-alibaba-dubbo/src/main/java/org/apache/shenyu/plugin/alibaba/dubbo/cache/AlibabaDubboConfigCache.java
+++ b/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-alibaba-dubbo/src/main/java/org/apache/shenyu/plugin/alibaba/dubbo/cache/AlibabaDubboConfigCache.java
@@ -26,7 +26,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.shenyu.common.constant.Constants;
 import org.apache.shenyu.common.dto.MetaData;
 import org.apache.shenyu.common.dto.convert.plugin.DubboRegisterConfig;
@@ -37,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -60,14 +58,9 @@ public final class AlibabaDubboConfigCache extends DubboConfigCache {
             .removalListener((RemovalListener<Object, ReferenceConfig<GenericService>>) notification -> {
                 ReferenceConfig<GenericService> config = notification.getValue();
                 if (Objects.nonNull(config)) {
-                    try {
-                        Field field = FieldUtils.getDeclaredField(config.getClass(), "ref", true);
-                        field.set(config, null);
-                        // After the configuration change, Dubbo destroys the instance, but does not empty it. If it is not handled,
-                        // it will get NULL when reinitializing and cause a NULL pointer problem.
-                    } catch (NullPointerException | IllegalAccessException e) {
-                        LOG.error("modify ref have exception", e);
-                    }
+                    // After the configuration change, Dubbo destroys the instance, but does not empty it. If it is not handled,
+                    // it will get NULL when reinitializing and cause a NULL pointer problem.
+                    config.destroy();
                 }
             })
             .build(new CacheLoader<String, ReferenceConfig<GenericService>>() {

--- a/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/cache/ApacheDubboConfigCache.java
+++ b/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/cache/ApacheDubboConfigCache.java
@@ -22,7 +22,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.RegistryConfig;
@@ -37,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -61,14 +59,9 @@ public final class ApacheDubboConfigCache extends DubboConfigCache {
             .removalListener((RemovalListener<Object, ReferenceConfig<GenericService>>) notification -> {
                 ReferenceConfig<GenericService> config = notification.getValue();
                 if (Objects.nonNull(config)) {
-                    try {
-                        Field field = FieldUtils.getDeclaredField(config.getClass(), "ref", true);
-                        field.set(config, null);
-                        // After the configuration change, Dubbo destroys the instance, but does not empty it. If it is not handled,
-                        // it will get NULL when reinitializing and cause a NULL pointer problem.
-                    } catch (NullPointerException | IllegalAccessException e) {
-                        LOG.error("modify ref have exception", e);
-                    }
+                    // After the configuration change, Dubbo destroys the instance, but does not empty it. If it is not handled,
+                    // it will get NULL when reinitializing and cause a NULL pointer problem.
+                    config.destroy();
                 }
             })
             .build(new CacheLoader<String, ReferenceConfig<GenericService>>() {


### PR DESCRIPTION
1 . Dubbo ReferenceConfig when removed from the cache, call ReferenceConfig destroy method.

2. update services.list

// Describe your PR here; eg. Fixes #issueNo

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
