### PR TITLE
Adapt grpc plugin compile requirement with apple m1 silicon

### DIFF
--- a/shenyu-examples/pom.xml
+++ b/shenyu-examples/pom.xml
@@ -72,4 +72,20 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>mac-apple-silicon</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <os.detected.classifier>osx-x86_64</os.detected.classifier>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
### Motivation
Let people who has mac with `apple m1 silicon` can easily compile. Otherwise the grpc plugin will error.

### Verifying this change

Compile on my `m1` and `intel` computer.
