### PR TITLE
[ISSUE #2695]  in jdk16, PowerMock internal error: Should never throw exception at this level 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <java-websocket.version>1.5.0</java-websocket.version>
         <mockito.version>3.5.15</mockito.version>
         <awaitility.version>4.0.3</awaitility.version>
+        <powermock.version>2.0.9</powermock.version>
         <nacos-client.version>2.0.0</nacos-client.version>
         <spring-security.version>5.3.10.RELEASE</spring-security.version>
         <grpc.version>1.33.1</grpc.version>
@@ -452,6 +453,18 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,6 @@
         <java-websocket.version>1.5.0</java-websocket.version>
         <mockito.version>3.5.15</mockito.version>
         <awaitility.version>4.0.3</awaitility.version>
-        <powermock.version>2.0.9</powermock.version>
         <nacos-client.version>2.0.0</nacos-client.version>
         <spring-security.version>5.3.10.RELEASE</spring-security.version>
         <grpc.version>1.33.1</grpc.version>
@@ -453,18 +452,6 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${awaitility.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/exception/ExceptionHandlersTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/exception/ExceptionHandlersTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DuplicateKeyException;
@@ -57,7 +56,6 @@ import static org.mockito.Mockito.when;
  * Test case for {@link ExceptionHandlers}.
  */
 @RunWith(MockitoJUnitRunner.class)
-@PrepareForTest(ExceptionHandlers.class)
 public final class ExceptionHandlersTest {
 
     private static Logger loggerSpy;

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketCollectorTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketCollectorTest.java
@@ -28,9 +28,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -49,12 +48,14 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Test case for WebsocketCollector.
+ * The TestCase for {@link WebsocketCollector}.
  */
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 @PrepareForTest(WebsocketCollector.class)
 public final class WebsocketCollectorTest {
 
@@ -105,7 +106,7 @@ public final class WebsocketCollectorTest {
         websocketCollector.onOpen(session);
         websocketCollector.onMessage(DataEventTypeEnum.MYSELF.name(), session);
         assertEquals(1L, getSessionSetSize());
-        Mockito.verify(syncDataService, Mockito.times(1)).syncAll(DataEventTypeEnum.MYSELF);
+        verify(syncDataService, times(1)).syncAll(DataEventTypeEnum.MYSELF);
         doNothing().when(loggerSpy).warn(anyString(), anyString());
         websocketCollector.onClose(session);
     }
@@ -138,12 +139,12 @@ public final class WebsocketCollectorTest {
         websocketCollector.onOpen(session);
         assertEquals(1L, getSessionSetSize());
         WebsocketCollector.send(null, DataEventTypeEnum.MYSELF);
-        Mockito.verify(basic, Mockito.times(0)).sendText(null);
+        verify(basic, times(0)).sendText(null);
         ThreadLocalUtils.put("sessionKey", session);
         WebsocketCollector.send("test_message_1", DataEventTypeEnum.MYSELF);
-        Mockito.verify(basic, Mockito.times(1)).sendText("test_message_1");
+        verify(basic, times(1)).sendText("test_message_1");
         WebsocketCollector.send("test_message_2", DataEventTypeEnum.CREATE);
-        Mockito.verify(basic, Mockito.times(1)).sendText("test_message_2");
+        verify(basic, times(1)).sendText("test_message_2");
         doNothing().when(loggerSpy).warn(anyString(), anyString());
         websocketCollector.onClose(session);
     }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketCollectorTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketCollectorTest.java
@@ -29,7 +29,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -56,7 +55,6 @@ import static org.mockito.Mockito.when;
  * The TestCase for {@link WebsocketCollector}.
  */
 @RunWith(MockitoJUnitRunner.Silent.class)
-@PrepareForTest(WebsocketCollector.class)
 public final class WebsocketCollectorTest {
 
     private static Logger loggerSpy;

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/zookeeper/HttpServiceDiscoveryTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/zookeeper/HttpServiceDiscoveryTest.java
@@ -35,10 +35,10 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 /**
- * The TestCase for HttpServiceDiscovery.
+ * The TestCase for {@link HttpServiceDiscovery}.
  */
 public final class HttpServiceDiscoveryTest {
 

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/MetaDataServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/MetaDataServiceTest.java
@@ -39,7 +39,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
@@ -64,7 +63,6 @@ import static org.mockito.Mockito.when;
  * Test cases for MetaDataService.
  */
 @RunWith(MockitoJUnitRunner.class)
-@PrepareForTest(MetaDataServiceImpl.class)
 public final class MetaDataServiceTest {
 
     private static Logger loggerSpy;

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
@@ -35,7 +35,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.powermock.core.classloader.annotations.PrepareForTest;
     
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -52,7 +51,6 @@ import static org.mockito.Mockito.when;
 /**
  * Test cases for {@link ShenyuClientRegisterDubboServiceImpl}.
  */
-@PrepareForTest(ShenyuClientRegisterDubboServiceImpl.class)
 @RunWith(MockitoJUnitRunner.Silent.class)
 public final class ShenyuClientRegisterDubboServiceImplTest {
     

--- a/shenyu-register-center/shenyu-register-server/shenyu-register-server-consul/src/test/java/org/apache/shenyu/register/server/consul/ConsulServerRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-server/shenyu-register-server-consul/src/test/java/org/apache/shenyu/register/server/consul/ConsulServerRegisterRepositoryTest.java
@@ -17,15 +17,11 @@
 
 package org.apache.shenyu.register.server.consul;
 
-import com.ecwid.consul.transport.DefaultHttpTransport;
 import com.ecwid.consul.v1.ConsulClient;
-import com.ecwid.consul.v1.ConsulRawClient;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.agent.model.Service;
 import com.ecwid.consul.v1.kv.model.GetValue;
 import com.google.common.collect.Maps;
-import org.apache.http.client.HttpClient;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.shenyu.common.enums.RpcTypeEnum;
 import org.apache.shenyu.common.utils.GsonUtils;
 import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
@@ -35,9 +31,7 @@ import org.apache.shenyu.register.server.api.ShenyuServerRegisterPublisher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 
@@ -48,28 +42,29 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({HttpClient.class, DefaultHttpTransport.class, ConsulRawClient.class, ConsulClient.class})
+/**
+ * The TestCase for {@link ConsulServerRegisterRepository}.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ConsulServerRegisterRepositoryTest {
 
     private ShenyuServerRegisterPublisher mockPublish() {
-        ShenyuServerRegisterPublisher publisher = Mockito.mock(ShenyuServerRegisterPublisher.class);
-        Mockito.doNothing().when(publisher).publish(any());
+        ShenyuServerRegisterPublisher publisher = mock(ShenyuServerRegisterPublisher.class);
+        doNothing().when(publisher).publish(any());
         return publisher;
     }
 
     @Bean
-    private ConsulClient mockConsulClient() throws Exception {
+    private ConsulClient mockConsulClient() {
         URIRegisterDTO mockServer = URIRegisterDTO.builder().appName("mockServer").contextPath("/mockServer").eventType(EventType.REGISTER).build();
         Service newService = new Service();
         Map<String, String> map = Maps.newHashMap();
         map.put("uri", GsonUtils.getInstance().toJson(mockServer));
         newService.setMeta(map);
-        CloseableHttpClient httpClientMock = Mockito.mock(CloseableHttpClient.class);
-        PowerMockito.whenNew(CloseableHttpClient.class).withNoArguments().thenReturn(httpClientMock);
-        PowerMockito.whenNew(DefaultHttpTransport.class).withAnyArguments().thenReturn(Mockito.mock(DefaultHttpTransport.class));
-        ConsulClient client = PowerMockito.mock(ConsulClient.class);
+        ConsulClient client = mock(ConsulClient.class);
 
         Map<String, Service> serviceHashMap = Maps.newHashMap();
         serviceHashMap.put(mockServer.getContextPath(), newService);
@@ -110,6 +105,5 @@ public class ConsulServerRegisterRepositoryTest {
                     ConsulConfigChangedEvent consulConfigChangedEvent = new ConsulConfigChangedEvent(this, 1L, mateData);
                     context.publishEvent(consulConfigChangedEvent);
                 });
-
     }
 }


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo
fixes #2695 
remove powermock from the follow class:
org/apache/shenyu/admin/listener/websocket/WebsocketCollectorTest.java
org/apache/shenyu/admin/service/MetaDataServiceTest.java
org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java 
org/apache/shenyu/register/server/consul/ConsulServerRegisterRepositoryTest.java 
org/apache/shenyu/admin/exception/ExceptionHandlersTest.java
org/apache/shenyu/admin/listener/zookeeper/HttpServiceDiscoveryTest.java

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
