### PR TITLE
[ISSUE #2699] Bootstrap start.sh script support starting with `shenyu-agent`

### DIFF
--- a/shenyu-dist/shenyu-bootstrap-dist/pom.xml
+++ b/shenyu-dist/shenyu-bootstrap-dist/pom.xml
@@ -30,11 +30,6 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.shenyu</groupId>
-            <artifactId>shenyu-agent-bootstrap</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/shenyu-dist/shenyu-bootstrap-dist/src/main/resources/bin/start.sh
+++ b/shenyu-dist/shenyu-bootstrap-dist/src/main/resources/bin/start.sh
@@ -38,7 +38,7 @@ if [ -n "$PIDS" ]; then
 fi
 
 CLASS_PATH=.:${DEPLOY_DIR}/conf:${DEPLOY_DIR}/lib/*:${EXT_LIB}/*
-JAVA_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss256k -XX:+DisableExplicitGC   -XX:LargePageSizeInBytes=128m"
+JAVA_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss512k -XX:+DisableExplicitGC   -XX:LargePageSizeInBytes=128m"
 
 version=`java -version 2>&1 | sed '1!d' | sed -e 's/"//g' | awk '{print $3}'`
 echo "current jdk version:${version}"
@@ -51,8 +51,15 @@ JAVA_OPTS="${JAVA_OPTS}"
 fi
 
 MAIN_CLASS=org.apache.shenyu.bootstrap.ShenyuBootstrapApplication
-echo "Starting the $SERVER_NAME ..."
 
-nohup java ${JAVA_OPTS} -classpath ${CLASS_PATH} ${MAIN_CLASS} >> ${LOG_FILES} 2>&1 &
+if [[ "$1" == "agent" ]]; then
+    echo "Starting the $SERVER_NAME with shenyu-agent ..."
+    SHENYU_AGENT=${DEPLOY_DIR}/agent/shenyu-agent.jar
+    nohup java ${JAVA_OPTS} -javaagent:${SHENYU_AGENT} -classpath ${CLASS_PATH} ${MAIN_CLASS} >> ${LOG_FILES} 2>&1 &
+else
+    echo "Starting the $SERVER_NAME ..."
+    nohup java ${JAVA_OPTS} -classpath ${CLASS_PATH} ${MAIN_CLASS} >> ${LOG_FILES} 2>&1 &
+fi
+
 sleep 1
 echo "Please check the log files: $LOG_FILES"


### PR DESCRIPTION
About #2699 

Changes in this pr:

1. Remove `shenyu-agent-bootstrap` in dist for 2 reasons:
    - This is no necessary import `shenyu-agent-bootstrap` here.
    - This will lead to some errors in `ShenyuAgentLocator.java`

2. Change `-Xss256k` in `start.sh` to `-Xss512k`:
    - Beacuse with `256k`, it start failed with following logs:
    - ![image](https://user-images.githubusercontent.com/62384022/148034087-adbe0372-0a99-4f2d-ac9a-73e367e07cfc.png)

3. Support starting with `shenyu-agent`.
    - User can start with `shenyu-agent` using `bin/start.sh agent`

