### PR TITLE
[type: refactor] shade for opentelemetry plugin in agent

### DIFF
--- a/.github/workflows/integrated-test-agent-tracing.yml
+++ b/.github/workflows/integrated-test-agent-tracing.yml
@@ -53,6 +53,7 @@ jobs:
         if: env.SKIP_CI != 'true'
         run: ./mvnw -B clean install -Pit4a -DskipTests -f ./shenyu-integrated-test/pom.xml
       - name: Setup Debug Session
+        if: env.SKIP_CI != 'true'
         uses: csexton/debugger-action@master
       - name: Start docker compose
         if: env.SKIP_CI != 'true'

--- a/.github/workflows/integrated-test-agent-tracing.yml
+++ b/.github/workflows/integrated-test-agent-tracing.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Build integrated tests for agent
         if: env.SKIP_CI != 'true'
         run: ./mvnw -B clean install -Pit4a -DskipTests -f ./shenyu-integrated-test/pom.xml
+      - name: Setup Debug Session
+        uses: csexton/debugger-action@master
       - name: Start docker compose
         if: env.SKIP_CI != 'true'
         run: docker-compose -f ./shenyu-integrated-test/shenyu-integrated-test-agent/shenyu-integrated-test-agent-tracing/${{ matrix.case }}/docker-compose.yml up -d

--- a/.github/workflows/integrated-test-agent-tracing.yml
+++ b/.github/workflows/integrated-test-agent-tracing.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Build integrated tests for agent
         if: env.SKIP_CI != 'true'
         run: ./mvnw -B clean install -Pit4a -DskipTests -f ./shenyu-integrated-test/pom.xml
-      - name: Setup Debug Session
-        if: env.SKIP_CI != 'true'
-        uses: csexton/debugger-action@master
       - name: Start docker compose
         if: env.SKIP_CI != 'true'
         run: docker-compose -f ./shenyu-integrated-test/shenyu-integrated-test-agent/shenyu-integrated-test-agent-tracing/${{ matrix.case }}/docker-compose.yml up -d

--- a/.github/workflows/integrated-test-agent-tracing.yml
+++ b/.github/workflows/integrated-test-agent-tracing.yml
@@ -20,7 +20,6 @@ on:
   push:
     branches:
       - master
-      - debug-in-ation
 
 jobs:
   build:

--- a/.github/workflows/integrated-test-agent-tracing.yml
+++ b/.github/workflows/integrated-test-agent-tracing.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - master
+      - debug-in-ation
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.prometheus</groupId>
                 <artifactId>simpleclient</artifactId>
                 <version>${prometheus-java-client.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -223,12 +223,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${okhttp.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>io.prometheus</groupId>
                 <artifactId>simpleclient</artifactId>
                 <version>${prometheus-java-client.version}</version>

--- a/shenyu-agent/shenyu-agent-plugins/shenyu-agent-plugin-tracing/shenyu-agent-plugin-tracing-opentelemetry/pom.xml
+++ b/shenyu-agent/shenyu-agent-plugins/shenyu-agent-plugin-tracing/shenyu-agent-plugin-tracing-opentelemetry/pom.xml
@@ -112,6 +112,10 @@
                                     <pattern>zipkin2</pattern>
                                     <shadedPattern>${shade.package}.zipkin2</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>net.bytebuddy</pattern>
+                                    <shadedPattern>${shade.package}.net.bytebuddy</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/shenyu-agent/shenyu-agent-plugins/shenyu-agent-plugin-tracing/shenyu-agent-plugin-tracing-opentelemetry/pom.xml
+++ b/shenyu-agent/shenyu-agent-plugins/shenyu-agent-plugin-tracing/shenyu-agent-plugin-tracing-opentelemetry/pom.xml
@@ -85,5 +85,38 @@
 
     <build>
         <finalName>${project.artifactId}-${project.version}.jar</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <createSourcesJar>true</createSourcesJar>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                            <relocations>
+                                <relocation>
+                                    <pattern>io.grpc</pattern>
+                                    <shadedPattern>${shade.package}.io.grpc</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okhttp3</pattern>
+                                    <shadedPattern>${shade.package}.okhttp3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>zipkin2</pattern>
+                                    <shadedPattern>${shade.package}.zipkin2</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
1. shade for opentelemetry plugin in agent
2. remove `okhttp` in dependencyManagement, because it will cause opentelemetry-jaeger-exporter to rely on the wrong version of okhttp.