### PR TITLE
[Task #2680] Add integration test for more dubbo api DubboMultiParamService

### DIFF
--- a/shenyu-integrated-test/shenyu-integrated-test-alibaba-dubbo/src/test/java/org/apache/shenyu/integrated/test/alibaba/dubbo/AlibabaDubboPluginMultiParamTest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-alibaba-dubbo/src/test/java/org/apache/shenyu/integrated/test/alibaba/dubbo/AlibabaDubboPluginMultiParamTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.integrated.test.alibaba.dubbo;
+
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.apache.shenyu.common.enums.PluginEnum;
+import org.apache.shenyu.integratedtest.common.AbstractPluginDataInit;
+import org.apache.shenyu.integratedtest.common.dto.ComplexBeanTest;
+import org.apache.shenyu.integratedtest.common.dto.ComplexBeanTestWithNameRequest;
+import org.apache.shenyu.integratedtest.common.dto.DubboTest;
+import org.apache.shenyu.integratedtest.common.dto.DubboTestListRequest;
+import org.apache.shenyu.integratedtest.common.dto.DubboTestListWithIdAndNameRequest;
+import org.apache.shenyu.integratedtest.common.dto.IdArrayAndNameRequest;
+import org.apache.shenyu.integratedtest.common.dto.IdStringArrayRequest;
+import org.apache.shenyu.integratedtest.common.dto.IdStringListRequest;
+import org.apache.shenyu.integratedtest.common.dto.IdsAndNameRequest;
+import org.apache.shenyu.integratedtest.common.helper.HttpHelper;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class AlibabaDubboPluginMultiParamTest extends AbstractPluginDataInit {
+    
+    @BeforeClass
+    public static void setup() throws IOException {
+        String pluginResult = initPlugin(PluginEnum.DUBBO.getName(), "{\"register\":\"zookeeper://shenyu-zk:2181\"}");
+        assertThat(pluginResult, is("success"));
+    }
+
+    @Test
+    public void testFindByIdsAndName() throws IOException {
+        final IdsAndNameRequest idsAndNameRequest = new IdsAndNameRequest();
+        idsAndNameRequest.setName("name");
+        idsAndNameRequest.setIds(Lists.newArrayList(123, 124, 125));
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/findByIdsAndName", idsAndNameRequest, DubboTest.class);
+        assertEquals("hello world shenyu alibaba dubbo param findByIdsAndName ：name", dubboTest.getName());
+        assertEquals("[123, 124, 125]", dubboTest.getId());
+    }
+
+    @Test
+    public void testFindByArrayIdsAndName() throws IOException {
+        final IdArrayAndNameRequest idArrayAndNameRequest = new IdArrayAndNameRequest();
+        idArrayAndNameRequest.setName("name");
+        idArrayAndNameRequest.setIds(IntStream.of(123, 124, 125).boxed().toArray(Integer[]::new));
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/findByArrayIdsAndName", idArrayAndNameRequest, DubboTest.class);
+        assertEquals("hello world shenyu alibaba dubbo param findByArrayIdsAndName ：name", dubboTest.getName());
+        assertEquals("[123, 124, 125]", dubboTest.getId());
+    }
+
+    @Test
+    public void testFindByStringArray() throws IOException {
+        final IdStringArrayRequest idStringArrayRequest = new IdStringArrayRequest();
+        idStringArrayRequest.setIds(IntStream.of(123, 124, 125).mapToObj(String::valueOf).toArray(String[]::new));
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/findByStringArray", idStringArrayRequest, DubboTest.class);
+        assertEquals("hello world shenyu alibaba dubbo param findByStringArray", dubboTest.getName());
+        assertEquals("[123, 124, 125]", dubboTest.getId());
+    }
+
+    @Test
+    public void testFindByListId() throws IOException {
+        final IdStringListRequest idStringListRequest = new IdStringListRequest();
+        idStringListRequest.setIds(Lists.newArrayList("123", "124", "125"));
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/findByListId", idStringListRequest, DubboTest.class);
+        assertEquals("hello world shenyu alibaba dubbo param findByListId", dubboTest.getName());
+        assertEquals("[123, 124, 125]", dubboTest.getId());
+    }
+
+    @Test
+    public void testBatchSave() throws IOException {
+        final DubboTestListRequest dubboTestListRequest = new DubboTestListRequest();
+        List<DubboTest> dubboTestList = new ArrayList<>();
+        dubboTestList.add(new DubboTest("123", "name123"));
+        dubboTestList.add(new DubboTest("124", "name124"));
+        dubboTestList.add(new DubboTest("125", "name125"));
+        dubboTestListRequest.setDubboTestList(dubboTestList);
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/batchSave", dubboTestListRequest, DubboTest.class);
+        assertEquals("hello world shenyu alibaba dubbo param batchSave :name123-name124-name125", dubboTest.getName());
+        assertEquals("123-124-125", dubboTest.getId());
+    }
+
+    @Test
+    public void testBatchSaveAndNameAndId() throws IOException {
+        final DubboTestListWithIdAndNameRequest request = new DubboTestListWithIdAndNameRequest();
+        request.setId("122");
+        request.setName("name122");
+        List<DubboTest> dubboTestList = new ArrayList<>();
+        dubboTestList.add(new DubboTest("123", "name123"));
+        dubboTestList.add(new DubboTest("124", "name124"));
+        dubboTestList.add(new DubboTest("125", "name125"));
+        request.setDubboTestList(dubboTestList);
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/batchSaveAndNameAndId", request, DubboTest.class);
+        assertEquals("hello world shenyu alibaba dubbo param batchSaveAndNameAndId :name122:name123-name124-name125", dubboTest.getName());
+        assertEquals("122", dubboTest.getId());
+    }
+
+    @Test
+    public void testSaveComplexBeanTest() throws IOException {
+        final ComplexBeanTest complexBeanTest = new ComplexBeanTest();
+        complexBeanTest.setDubboTest(new DubboTest("122", "name"));
+        complexBeanTest.setIdLists(Lists.newArrayList("123", "124"));
+        Map<String, String> idMaps = new HashMap<>();
+        idMaps.put("key_abc", "value_abc");
+        idMaps.put("key_cbd", "value_cbd");
+        complexBeanTest.setIdMaps(idMaps);
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/saveComplexBeanTest", complexBeanTest, DubboTest.class);
+        assertEquals("hello world shenyu alibaba dubbo param saveComplexBeanTest :name", dubboTest.getName());
+        assertEquals("[123, 124]", dubboTest.getId());
+    }
+
+    @Test
+    public void testSaveComplexBeanTestAndName() throws IOException {
+        final ComplexBeanTestWithNameRequest request = new ComplexBeanTestWithNameRequest();
+        ComplexBeanTest complexBeanTest = new ComplexBeanTest();
+        complexBeanTest.setDubboTest(new DubboTest("122", "name122"));
+        complexBeanTest.setIdLists(Lists.newArrayList("123", "124"));
+        Map<String, String> idMaps = new HashMap<>();
+        idMaps.put("key_abc", "value_abc");
+        idMaps.put("key_cbd", "value_cbd");
+        complexBeanTest.setIdMaps(idMaps);
+        request.setComplexBeanTest(complexBeanTest);
+        request.setName("name");
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/saveComplexBeanTestAndName", request, DubboTest.class);
+        assertEquals("hello world shenyu alibaba dubbo param saveComplexBeanTestAndName :name122-name", dubboTest.getName());
+        assertEquals("[123, 124]", dubboTest.getId());
+    }
+}

--- a/shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/src/test/java/org/apache/shenyu/integrated/test/alibaba/dubbo/ApacheDubboPluginMultiParamTest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/src/test/java/org/apache/shenyu/integrated/test/alibaba/dubbo/ApacheDubboPluginMultiParamTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.integrated.test.alibaba.dubbo;
+
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.apache.shenyu.common.enums.PluginEnum;
+import org.apache.shenyu.integratedtest.common.AbstractPluginDataInit;
+import org.apache.shenyu.integratedtest.common.dto.ComplexBeanTest;
+import org.apache.shenyu.integratedtest.common.dto.ComplexBeanTestWithNameRequest;
+import org.apache.shenyu.integratedtest.common.dto.DubboTest;
+import org.apache.shenyu.integratedtest.common.dto.DubboTestListRequest;
+import org.apache.shenyu.integratedtest.common.dto.DubboTestListWithIdAndNameRequest;
+import org.apache.shenyu.integratedtest.common.dto.IdArrayAndNameRequest;
+import org.apache.shenyu.integratedtest.common.dto.IdStringArrayRequest;
+import org.apache.shenyu.integratedtest.common.dto.IdStringListRequest;
+import org.apache.shenyu.integratedtest.common.dto.IdsAndNameRequest;
+import org.apache.shenyu.integratedtest.common.helper.HttpHelper;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class ApacheDubboPluginMultiParamTest extends AbstractPluginDataInit {
+    
+    @BeforeClass
+    public static void setup() throws IOException {
+        String pluginResult = initPlugin(PluginEnum.DUBBO.getName(), "{\"register\":\"zookeeper://shenyu-zk:2181\"}");
+        assertThat(pluginResult, is("success"));
+    }
+
+    @Test
+    public void testFindByIdsAndName() throws IOException {
+        final IdsAndNameRequest idsAndNameRequest = new IdsAndNameRequest();
+        idsAndNameRequest.setName("name");
+        idsAndNameRequest.setIds(Lists.newArrayList(123, 124, 125));
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/findByIdsAndName", idsAndNameRequest, DubboTest.class);
+        assertEquals("hello world shenyu apache dubbo param findByIdsAndName ：name", dubboTest.getName());
+        assertEquals("[123, 124, 125]", dubboTest.getId());
+    }
+
+    @Test
+    public void testFindByArrayIdsAndName() throws IOException {
+        final IdArrayAndNameRequest idArrayAndNameRequest = new IdArrayAndNameRequest();
+        idArrayAndNameRequest.setName("name");
+        idArrayAndNameRequest.setIds(IntStream.of(123, 124, 125).boxed().toArray(Integer[]::new));
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/findByArrayIdsAndName", idArrayAndNameRequest, DubboTest.class);
+        assertEquals("hello world shenyu apache dubbo param findByArrayIdsAndName ：name", dubboTest.getName());
+        assertEquals("[123, 124, 125]", dubboTest.getId());
+    }
+
+    @Test
+    public void testFindByStringArray() throws IOException {
+        final IdStringArrayRequest idStringArrayRequest = new IdStringArrayRequest();
+        idStringArrayRequest.setIds(IntStream.of(123, 124, 125).mapToObj(String::valueOf).toArray(String[]::new));
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/findByStringArray", idStringArrayRequest, DubboTest.class);
+        assertEquals("hello world shenyu apache dubbo param findByStringArray", dubboTest.getName());
+        assertEquals("[123, 124, 125]", dubboTest.getId());
+    }
+
+    @Test
+    public void testFindByListId() throws IOException {
+        final IdStringListRequest idStringListRequest = new IdStringListRequest();
+        idStringListRequest.setIds(Lists.newArrayList("123", "124", "125"));
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/findByListId", idStringListRequest, DubboTest.class);
+        assertEquals("hello world shenyu apache dubbo param findByListId", dubboTest.getName());
+        assertEquals("[123, 124, 125]", dubboTest.getId());
+    }
+
+    @Test
+    public void testBatchSave() throws IOException {
+        final DubboTestListRequest dubboTestListRequest = new DubboTestListRequest();
+        List<DubboTest> dubboTestList = new ArrayList<>();
+        dubboTestList.add(new DubboTest("123", "name123"));
+        dubboTestList.add(new DubboTest("124", "name124"));
+        dubboTestList.add(new DubboTest("125", "name125"));
+        dubboTestListRequest.setDubboTestList(dubboTestList);
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/batchSave", dubboTestListRequest, DubboTest.class);
+        assertEquals("hello world shenyu apache dubbo param batchSave :name123-name124-name125", dubboTest.getName());
+        assertEquals("123-124-125", dubboTest.getId());
+    }
+
+    @Test
+    public void testBatchSaveAndNameAndId() throws IOException {
+        final DubboTestListWithIdAndNameRequest request = new DubboTestListWithIdAndNameRequest();
+        request.setId("122");
+        request.setName("name122");
+        List<DubboTest> dubboTestList = new ArrayList<>();
+        dubboTestList.add(new DubboTest("123", "name123"));
+        dubboTestList.add(new DubboTest("124", "name124"));
+        dubboTestList.add(new DubboTest("125", "name125"));
+        request.setDubboTestList(dubboTestList);
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/batchSaveAndNameAndId", request, DubboTest.class);
+        assertEquals("hello world shenyu apache dubbo param batchSaveAndNameAndId :name122:name123-name124-name125", dubboTest.getName());
+        assertEquals("122", dubboTest.getId());
+    }
+
+    @Test
+    public void testSaveComplexBeanTest() throws IOException {
+        final ComplexBeanTest complexBeanTest = new ComplexBeanTest();
+        complexBeanTest.setDubboTest(new DubboTest("122", "name"));
+        complexBeanTest.setIdLists(Lists.newArrayList("123", "124"));
+        Map<String, String> idMaps = new HashMap<>();
+        idMaps.put("key_abc", "value_abc");
+        idMaps.put("key_cbd", "value_cbd");
+        complexBeanTest.setIdMaps(idMaps);
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/saveComplexBeanTest", complexBeanTest, DubboTest.class);
+        assertEquals("hello world shenyu apache dubbo param saveComplexBeanTest :name", dubboTest.getName());
+        assertEquals("[123, 124]", dubboTest.getId());
+    }
+
+    @Test
+    public void testSaveComplexBeanTestAndName() throws IOException {
+        final ComplexBeanTestWithNameRequest request = new ComplexBeanTestWithNameRequest();
+        ComplexBeanTest complexBeanTest = new ComplexBeanTest();
+        complexBeanTest.setDubboTest(new DubboTest("122", "name122"));
+        complexBeanTest.setIdLists(Lists.newArrayList("123", "124"));
+        Map<String, String> idMaps = new HashMap<>();
+        idMaps.put("key_abc", "value_abc");
+        idMaps.put("key_cbd", "value_cbd");
+        complexBeanTest.setIdMaps(idMaps);
+        request.setComplexBeanTest(complexBeanTest);
+        request.setName("name");
+        DubboTest dubboTest = HttpHelper.INSTANCE.postGateway("/dubbo/saveComplexBeanTestAndName", request, DubboTest.class);
+        assertEquals("hello world shenyu alibaba dubbo param saveComplexBeanTestAndName :name122-name", dubboTest.getName());
+        assertEquals("[123, 124]", dubboTest.getId());
+    }
+}

--- a/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/ComplexBeanTest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/ComplexBeanTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.integratedtest.common.dto;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+
+/**
+ * The type Complex bean test.
+ */
+public class ComplexBeanTest implements Serializable {
+
+    /**
+     * DubboTest property.
+     */
+    private DubboTest dubboTest;
+
+    /**
+     * id String list property.
+     */
+    private List<String> idLists;
+
+    /**
+     * idMaps map property.
+     */
+    private Map<String, String> idMaps;
+
+    public ComplexBeanTest() { }
+
+    public ComplexBeanTest(final DubboTest dubboTest, final List<String> idLists, final Map<String, String> idMaps) {
+        this.dubboTest = dubboTest;
+        this.idLists = idLists;
+        this.idMaps = idMaps;
+    }
+
+    /**
+     * Get dubboTest.
+     *
+     * @return dubboTest
+     */
+    public DubboTest getDubboTest() {
+        return dubboTest;
+    }
+
+    /**
+     * Set dubboTest.
+     *
+     * @param dubboTest dubboTest
+     */
+    public void setDubboTest(final DubboTest dubboTest) {
+        this.dubboTest = dubboTest;
+    }
+
+    /**
+     * Get idLists.
+     *
+     * @return idLists
+     */
+    public List<String> getIdLists() {
+        return idLists;
+    }
+
+    /**
+     * Set idLists.
+     *
+     * @param idLists idLists
+     */
+    public void setIdLists(final List<String> idLists) {
+        this.idLists = idLists;
+    }
+
+    /**
+     * Get idMaps.
+     *
+     * @return idMaps
+     */
+    public Map<String, String> getIdMaps() {
+        return idMaps;
+    }
+
+    /**
+     * Set idMaps.
+     *
+     * @param idMaps idMaps
+     */
+    public void setIdMaps(final Map<String, String> idMaps) {
+        this.idMaps = idMaps;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ComplexBeanTest.class.getSimpleName() + "[", "]")
+                .add("dubboTest=" + dubboTest)
+                .add("idLists=" + idLists)
+                .add("idMaps=" + idMaps)
+                .toString();
+    }
+
+}

--- a/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/ComplexBeanTestWithNameRequest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/ComplexBeanTestWithNameRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.integratedtest.common.dto;
+
+import java.io.Serializable;
+
+/**
+ * The type Complex bean test with name request.
+ */
+public class ComplexBeanTestWithNameRequest implements Serializable {
+
+    /**
+     * Request param complexBeanTest.
+     */
+    private ComplexBeanTest complexBeanTest;
+
+    /**
+     * Request param name.
+     */
+    private String name;
+
+    public ComplexBeanTestWithNameRequest() { }
+
+    public ComplexBeanTestWithNameRequest(final ComplexBeanTest complexBeanTest, final String name) {
+        this.complexBeanTest = complexBeanTest;
+        this.name = name;
+    }
+
+    /**
+     * Get complexBeanTest.
+     *
+     * @return complexBeanTest
+     */
+    public ComplexBeanTest getComplexBeanTest() {
+        return complexBeanTest;
+    }
+
+    /**
+     * Set complexBeanTest.
+     *
+     * @param complexBeanTest complexBeanTest
+     */
+    public void setComplexBeanTest(final ComplexBeanTest complexBeanTest) {
+        this.complexBeanTest = complexBeanTest;
+    }
+
+    /**
+     * Get name.
+     *
+     * @return name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set name.
+     *
+     * @param name name
+     */
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/DubboTestListRequest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/DubboTestListRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.integratedtest.common.dto;
+
+import java.util.List;
+
+/**
+ * Request object contains DubboTest list property.
+ */
+public class DubboTestListRequest {
+    /**
+     * Request param DubboTest list.
+     */
+    private List<DubboTest> dubboTestList;
+
+    public DubboTestListRequest() { }
+
+    public DubboTestListRequest(final List<DubboTest> dubboTestList) {
+        this.dubboTestList = dubboTestList;
+    }
+
+    /**
+     * Return request param DubboTest list.
+     * @return dubboTestList Request param DubboTest list.
+     */
+    public List<DubboTest> getDubboTestList() {
+        return dubboTestList;
+    }
+
+    /**
+     * Set request param DubboTest list.
+     * @param dubboTestList Request param DubboTest list.
+     */
+    public void setDubboTestList(final List<DubboTest> dubboTestList) {
+        this.dubboTestList = dubboTestList;
+    }
+}

--- a/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/DubboTestListWithIdAndNameRequest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/DubboTestListWithIdAndNameRequest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.integratedtest.common.dto;
+
+import java.util.List;
+
+/**
+ * Request object contains DubboTest list property.
+ */
+public class DubboTestListWithIdAndNameRequest {
+    /**
+     * Request param DubboTest list.
+     */
+    private List<DubboTest> dubboTestList;
+
+    /**
+     * Request param id.
+     */
+    private String id;
+
+    /**
+     * Request param name.
+     */
+    private String name;
+
+    public DubboTestListWithIdAndNameRequest() { }
+
+    public DubboTestListWithIdAndNameRequest(final List<DubboTest> dubboTestList, final String id, final String name) {
+        this.dubboTestList = dubboTestList;
+        this.id = id;
+        this.name = name;
+    }
+
+    /**
+     * Return request param DubboTest list.
+     * @return dubboTestList Request param DubboTest list.
+     */
+    public List<DubboTest> getDubboTestList() {
+        return dubboTestList;
+    }
+
+    /**
+     * Set request param DubboTest list.
+     * @param dubboTestList Request param DubboTest list.
+     */
+    public void setDubboTestList(final List<DubboTest> dubboTestList) {
+        this.dubboTestList = dubboTestList;
+    }
+
+    /**
+     * Get request param id.
+     * @return name Request param id.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set request param id.
+     * @param id Request param id.
+     */
+    public void setId(final String id) {
+        this.id = id;
+    }
+
+    /**
+     * Get request param name.
+     * @return name Request param name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set request param name.
+     * @param name Request param name.
+     */
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/IdStringArrayRequest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/IdStringArrayRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.integratedtest.common.dto;
+
+/**
+ * Request object contains string id array property.
+ */
+public class IdStringArrayRequest {
+    /**
+     * Request param id array.
+     */
+    private String[] ids;
+
+    public IdStringArrayRequest() { }
+
+    public IdStringArrayRequest(final String[] ids) {
+        this.ids = ids;
+    }
+
+    /**
+     * Return request param id list.
+     * @return ids Request param id list.
+     */
+    public String[] getIds() {
+        return ids;
+    }
+
+    /**
+     * Set request param id list.
+     * @param ids Request param id list.
+     */
+    public void setIds(final String[] ids) {
+        this.ids = ids;
+    }
+}

--- a/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/IdStringListRequest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/IdStringListRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.integratedtest.common.dto;
+
+import java.util.List;
+
+/**
+ * Request object contains string id list property.
+ */
+public class IdStringListRequest {
+    /**
+     * Request param id array.
+     */
+    private List<String> ids;
+
+    public IdStringListRequest() { }
+
+    public IdStringListRequest(final List<String> ids) {
+        this.ids = ids;
+    }
+
+    /**
+     * Return request param id list.
+     * @return ids Request param id list.
+     */
+    public List<String> getIds() {
+        return ids;
+    }
+
+    /**
+     * Set request param id list.
+     * @param ids Request param id list.
+     */
+    public void setIds(final List<String> ids) {
+        this.ids = ids;
+    }
+}


### PR DESCRIPTION
#2680 

1. Add integrated test for DubboMultiParamService in shenyu-examples-apache-dubbo-service
2. Add integrated test for DubboMultiParamService in shenyu-examples-alibaba-dubbo-service


Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
