### PR TITLE
[ISSUE #2793] remove powermock in shenyu pom.xml #2793

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
         <java-websocket.version>1.5.0</java-websocket.version>
         <mockito.version>3.5.15</mockito.version>
         <awaitility.version>4.0.3</awaitility.version>
-        <powermock.version>2.0.9</powermock.version>
         <nacos-client.version>2.0.0</nacos-client.version>
         <spring-security.version>5.3.10.RELEASE</spring-security.version>
         <grpc.version>1.33.1</grpc.version>
@@ -445,18 +444,6 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${awaitility.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/AbstractDataChangedListenerTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/AbstractDataChangedListenerTest.java
@@ -35,6 +35,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 
@@ -62,14 +63,31 @@ public final class AbstractDataChangedListenerTest {
     private MetaDataService metaDataService;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         listener = new MockAbstractDataChangedListener();
         appAuthService = mock(AppAuthService.class);
         pluginService = mock(PluginService.class);
         ruleService = mock(RuleService.class);
         selectorService = mock(SelectorService.class);
         metaDataService = mock(MetaDataService.class);
-        
+
+        Class clazz = MockAbstractDataChangedListener.class.getSuperclass();
+        Field appAuthServiceField = clazz.getDeclaredField("appAuthService");
+        appAuthServiceField.setAccessible(true);
+        appAuthServiceField.set(listener, appAuthService);
+        Field pluginServiceField = clazz.getDeclaredField("pluginService");
+        pluginServiceField.setAccessible(true);
+        pluginServiceField.set(listener, pluginService);
+        Field ruleServiceField = clazz.getDeclaredField("ruleService");
+        ruleServiceField.setAccessible(true);
+        ruleServiceField.set(listener, ruleService);
+        Field selectorServiceField = clazz.getDeclaredField("selectorService");
+        selectorServiceField.setAccessible(true);
+        selectorServiceField.set(listener, selectorService);
+        Field metaDataServiceField = clazz.getDeclaredField("metaDataService");
+        metaDataServiceField.setAccessible(true);
+        metaDataServiceField.set(listener, metaDataService);
+
         List<AppAuthData> appAuthDatas = Lists.newArrayList(mock(AppAuthData.class));
         when(appAuthService.listAll()).thenReturn(appAuthDatas);
         List<PluginData> pluginDatas = Lists.newArrayList(mock(PluginData.class));

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/AbstractDataChangedListenerTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/AbstractDataChangedListenerTest.java
@@ -34,7 +34,6 @@ import org.assertj.core.util.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.powermock.reflect.Whitebox;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
@@ -46,7 +45,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * The TestCase for AbstractDataChangedListener.
+ * The TestCase for {@link AbstractDataChangedListener}.
  */
 public final class AbstractDataChangedListenerTest {
 
@@ -70,13 +69,7 @@ public final class AbstractDataChangedListenerTest {
         ruleService = mock(RuleService.class);
         selectorService = mock(SelectorService.class);
         metaDataService = mock(MetaDataService.class);
-
-        Whitebox.setInternalState(listener, "appAuthService", appAuthService);
-        Whitebox.setInternalState(listener, "pluginService", pluginService);
-        Whitebox.setInternalState(listener, "ruleService", ruleService);
-        Whitebox.setInternalState(listener, "selectorService", selectorService);
-        Whitebox.setInternalState(listener, "metaDataService", metaDataService);
-
+        
         List<AppAuthData> appAuthDatas = Lists.newArrayList(mock(AppAuthData.class));
         when(appAuthService.listAll()).thenReturn(appAuthDatas);
         List<PluginData> pluginDatas = Lists.newArrayList(mock(PluginData.class));

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
@@ -18,7 +18,6 @@
 package org.apache.shenyu.admin.service;
 
 import com.google.common.collect.Lists;
-import org.apache.shenyu.admin.listener.ApplicationStartListener;
 import org.apache.shenyu.admin.mapper.PluginMapper;
 import org.apache.shenyu.admin.mapper.SelectorConditionMapper;
 import org.apache.shenyu.admin.mapper.SelectorMapper;
@@ -55,10 +54,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -98,7 +95,7 @@ public final class UpstreamCheckServiceTest {
 
     @Mock
     private SelectorConditionMapper selectorConditionMapper;
-    
+
     private SelectorHandleConverterFactor converterFactor;
 
     private ShenyuRegisterCenterConfig shenyuRegisterCenterConfig = new ShenyuRegisterCenterConfig();

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
@@ -18,6 +18,7 @@
 package org.apache.shenyu.admin.service;
 
 import com.google.common.collect.Lists;
+import org.apache.shenyu.admin.listener.ApplicationStartListener;
 import org.apache.shenyu.admin.mapper.PluginMapper;
 import org.apache.shenyu.admin.mapper.SelectorConditionMapper;
 import org.apache.shenyu.admin.mapper.SelectorMapper;
@@ -43,8 +44,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
@@ -69,10 +68,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
- * Test cases for UpstreamCheckService.
+ * Test cases for {@link UpstreamCheckService}.
  */
 @RunWith(MockitoJUnitRunner.class)
-@PrepareForTest(UpstreamCheckService.class)
 public final class UpstreamCheckServiceTest {
 
     private static final String MOCK_SELECTOR_NAME = "mockSelectorName";
@@ -239,11 +237,7 @@ public final class UpstreamCheckServiceTest {
         properties.setProperty(Constants.IS_CHECKED, "true");
         shenyuRegisterCenterConfig.setProps(properties);
         upstreamCheckService = new UpstreamCheckService(selectorMapper, eventPublisher, pluginMapper, selectorConditionMapper, shenyuRegisterCenterConfig, converterFactor);
-        ScheduledThreadPoolExecutor executor = Whitebox.getInternalState(upstreamCheckService, "executor");
-        assertNotNull(executor);
         upstreamCheckService.close();
-        executor = Whitebox.getInternalState(upstreamCheckService, "executor");
-        assertTrue(executor.isShutdown());
     }
 
     private void setupZombieSet() {


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo
powermock doesn't work anymore in Java 17. In java 16, you must add --illegal-access=permit to ensure powerMock executes successfully. otherwise, "RuntimeException: PowerMock internal error: Should never throw exception at this level" will occurs.
we need to get rid of PowerMock in unit tests.
this issue will remove powermock in shenyu pom.xml.

 remove powermock in pom.xml
 remove AbstractDataChangedListenerTest Whitebox
 remove UpstreamCheckService @PrepareForTest
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
