### PR TITLE
[ISSUE 2827] shenyu_checkstyle.xml does not support annotations from junit5

### DIFF
--- a/script/shenyu_checkstyle.xml
+++ b/script/shenyu_checkstyle.xml
@@ -228,7 +228,7 @@
         <module name="SummaryJavadoc"/>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
-            <property name="allowedAnnotations" value="Override, Test, Before, After, BeforeClass, AfterClass, Parameterized, Parameters"/>
+            <property name="allowedAnnotations" value="Override, Test, Before, After, BeforeClass, AfterClass, Parameterized, Parameters, BeforeEach, AfterEach, BeforeAll, AfterAll, ParameterizedTest, TestMethodOrder"/>
             <property name="ignoreMethodNamesRegex" value="^assert.*$|^verify.*$"/>
             <property name="tokens" value="METHOD_DEF, ANNOTATION_FIELD_DEF"/>
         </module>


### PR DESCRIPTION
In junit 5,Some new annotations have be used, such as:
@ BeforeEach, @ AfterEach, @ BeforeAll, @ AfterAll, @ ParameterizedTest, @ TestMethodOrder.
Therefore, the shenyu_checkstyle.xml file must be modified.
// Describe your PR here; eg. Fixes #issueNo
Fixes #2827 
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
