### PR TITLE
[ISSUE 2830] Update junit4 to junit5 - remove dup dependencies in sub-modules and make wire-mock compatible

### DIFF
--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-http/src/test/java/org/apache/shenyu/register/client/http/OkHttpToolsTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-http/src/test/java/org/apache/shenyu/register/client/http/OkHttpToolsTest.java
@@ -17,44 +17,50 @@
 
 package org.apache.shenyu.register.client.http;
 
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import org.apache.shenyu.register.client.http.utils.OkHttpTools;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import wiremock.com.google.common.net.HttpHeaders;
 import wiremock.org.apache.http.entity.ContentType;
 
 import java.io.IOException;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * Test case for {@link OkHttpTools}.
  */
 public final class OkHttpToolsTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort(), false);
+    private WireMockServer wireMockServer;
 
     private String url;
 
     private final String json = "{\"appName\":\"shenyu\"}";
 
-    @Before
+    @BeforeEach
     public void setUpWireMock() {
-        wireMockRule.stubFor(post(urlPathEqualTo("/"))
+        this.wireMockServer = new WireMockServer(
+                options()
+                        .extensions(new ResponseTemplateTransformer(false))
+                        .port(8081));
+        wireMockServer.stubFor(post(urlPathEqualTo("/"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .withBody(json)
                         .withStatus(200))
         );
-        url = "http://localhost:" + wireMockRule.port();
+        this.wireMockServer.start();
+        url = "http://localhost:" + wireMockServer.port();
     }
 
     @Test

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-http/src/test/java/org/apache/shenyu/register/client/http/OkHttpToolsTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-http/src/test/java/org/apache/shenyu/register/client/http/OkHttpToolsTest.java
@@ -27,9 +27,7 @@ import wiremock.org.apache.http.entity.ContentType;
 
 import java.io.IOException;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
@@ -52,14 +50,14 @@ public final class OkHttpToolsTest {
         this.wireMockServer = new WireMockServer(
                 options()
                         .extensions(new ResponseTemplateTransformer(false))
-                        .port(8081));
+                        .dynamicPort());
+        this.wireMockServer.start();
         wireMockServer.stubFor(post(urlPathEqualTo("/"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .withBody(json)
                         .withStatus(200))
         );
-        this.wireMockServer.start();
         url = "http://localhost:" + wireMockServer.port();
     }
 

--- a/shenyu-sync-data-center/shenyu-sync-data-consul/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-consul/pom.xml
@@ -42,11 +42,6 @@
             <artifactId>consul-api</artifactId>
             <version>${consul.api.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/shenyu-sync-data-center/shenyu-sync-data-etcd/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-etcd/pom.xml
@@ -36,11 +36,6 @@
             <artifactId>jetcd-core</artifactId>
             <version>0.5.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/HttpSyncDataServiceTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/HttpSyncDataServiceTest.java
@@ -49,7 +49,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -80,7 +79,8 @@ public final class HttpSyncDataServiceTest {
         this.wireMockServer = new WireMockServer(
                 options()
                         .extensions(new ResponseTemplateTransformer(false))
-                        .port(8081));
+                        .dynamicPort());
+        this.wireMockServer.start();
         wireMockServer.stubFor(get(urlPathEqualTo("/platform/login"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
@@ -99,7 +99,6 @@ public final class HttpSyncDataServiceTest {
                         .withBody(this.mockConfigsListenResponseJson())
                         .withStatus(200))
         );
-        this.wireMockServer.start();
 
         HttpConfig httpConfig = new HttpConfig();
         httpConfig.setUrl(this.getMockServerUrl());

--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/HttpSyncDataServiceTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/HttpSyncDataServiceTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.shenyu.sync.data.http;
 
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import org.apache.shenyu.common.dto.ConfigData;
 import org.apache.shenyu.common.dto.PluginData;
 import org.apache.shenyu.common.enums.ConfigGroupEnum;
@@ -28,12 +28,11 @@ import org.apache.shenyu.sync.data.api.AuthDataSubscriber;
 import org.apache.shenyu.sync.data.api.MetaDataSubscriber;
 import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
 import org.apache.shenyu.sync.data.http.config.HttpConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -46,17 +45,19 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class HttpSyncDataServiceTest {
 
     /**
@@ -64,8 +65,7 @@ public final class HttpSyncDataServiceTest {
      */
     private static final Logger LOG = LoggerFactory.getLogger(HttpSyncDataServiceTest.class);
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort(), false);
+    private WireMockServer wireMockServer;
 
     private PluginDataSubscriber pluginDataSubscriber;
 
@@ -75,26 +75,31 @@ public final class HttpSyncDataServiceTest {
 
     private HttpSyncDataService httpSyncDataService;
 
-    @Before
+    @BeforeEach
     public void before() {
-        wireMockRule.stubFor(get(urlPathEqualTo("/platform/login"))
+        this.wireMockServer = new WireMockServer(
+                options()
+                        .extensions(new ResponseTemplateTransformer(false))
+                        .port(8081));
+        wireMockServer.stubFor(get(urlPathEqualTo("/platform/login"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .withBody(this.mockLoginResponseJson())
                         .withStatus(200))
         );
-        wireMockRule.stubFor(get(urlPathEqualTo("/configs/fetch"))
+        wireMockServer.stubFor(get(urlPathEqualTo("/configs/fetch"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .withBody(this.mockConfigsFetchResponseJson())
                         .withStatus(200))
         );
-        wireMockRule.stubFor(post(urlPathEqualTo("/configs/listener"))
+        wireMockServer.stubFor(post(urlPathEqualTo("/configs/listener"))
                 .willReturn(aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .withBody(this.mockConfigsListenResponseJson())
                         .withStatus(200))
         );
+        this.wireMockServer.start();
 
         HttpConfig httpConfig = new HttpConfig();
         httpConfig.setUrl(this.getMockServerUrl());
@@ -111,7 +116,7 @@ public final class HttpSyncDataServiceTest {
                 Collections.singletonList(metaDataSubscriber), Collections.singletonList(authDataSubscriber));
     }
 
-    @After
+    @AfterEach
     public void after() {
         try {
             httpSyncDataService.close();
@@ -133,7 +138,7 @@ public final class HttpSyncDataServiceTest {
     }
 
     private String getMockServerUrl() {
-        return "http://127.0.0.1:" + wireMockRule.port();
+        return "http://127.0.0.1:" + wireMockServer.port();
     }
 
     // mock configs listen api response

--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/pom.xml
@@ -49,10 +49,5 @@
             <version>${undertow.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml
@@ -52,11 +52,5 @@
             <version>${curator-test.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->

About #2830 , remove dup dependencies in sub-moduels.

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
