### PR TITLE
Remove the  host checksum

### DIFF
--- a/shenyu-plugin/shenyu-plugin-monitor/src/main/java/org/apache/shenyu/plugin/monitor/handler/MonitorPluginDataHandler.java
+++ b/shenyu-plugin/shenyu-plugin-monitor/src/main/java/org/apache/shenyu/plugin/monitor/handler/MonitorPluginDataHandler.java
@@ -56,7 +56,6 @@ public class MonitorPluginDataHandler implements PluginDataHandler {
     
     private boolean checkConfig(final MetricsConfig monitorConfig) {
         return Objects.nonNull(monitorConfig)
-                && StringUtils.isNoneBlank(monitorConfig.getHost())
                 && Objects.nonNull(monitorConfig.getPort())
                 && Objects.nonNull(monitorConfig.getAsync());
     }

--- a/shenyu-plugin/shenyu-plugin-monitor/src/main/java/org/apache/shenyu/plugin/monitor/handler/MonitorPluginDataHandler.java
+++ b/shenyu-plugin/shenyu-plugin-monitor/src/main/java/org/apache/shenyu/plugin/monitor/handler/MonitorPluginDataHandler.java
@@ -18,7 +18,6 @@
 package org.apache.shenyu.plugin.monitor.handler;
 
 import java.util.Objects;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.common.dto.PluginData;
 import org.apache.shenyu.common.enums.PluginEnum;
 import org.apache.shenyu.common.utils.GsonUtils;


### PR DESCRIPTION

Remove the host checksum so that the gateway in the cluster can start the monitoring service.


![image](https://user-images.githubusercontent.com/50908453/153985463-78f4cb9e-0cb8-4ff4-ba2f-fa0247798722.png)
The location of the image displayed in the above configuration plugin is possible without the configuration of host.


![image](https://user-images.githubusercontent.com/50908453/153985814-27f7194e-e4f2-46cc-a44d-5d20d8317836.png)
Checking the source code also allows not to configure the host.

![image](https://user-images.githubusercontent.com/50908453/153986042-7a0c2a0a-d4d6-41cf-8550-663c457bfa6f.png)
But this line of code checks that the host must be configured, which is obviously not correct
