### PR TITLE
[Volunteer #2892] Synchronize sorting of plugins.

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/PluginTransfer.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/PluginTransfer.java
@@ -47,6 +47,7 @@ public enum PluginTransfer {
                         .config(v.getConfig())
                         .role(v.getRole())
                         .enabled(v.getEnabled())
+                        .sort(v.getSort())
                         .build())
                 .orElse(null);
     }
@@ -65,6 +66,7 @@ public enum PluginTransfer {
                         .config(v.getConfig())
                         .role(v.getRole())
                         .enabled(v.getEnabled())
+                        .sort(v.getSort())
                         .build())
                 .orElse(null);
     }

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/dto/PluginData.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/dto/PluginData.java
@@ -35,6 +35,8 @@ public class PluginData {
     private String role;
 
     private Boolean enabled;
+    
+    private Integer sort;
 
     /**
      * no args constructor.
@@ -43,7 +45,7 @@ public class PluginData {
     }
 
     /**
-     * all args constructor.
+     * all args constructor without sort.
      *
      * @param id      id
      * @param name    name
@@ -58,6 +60,26 @@ public class PluginData {
         this.role = role;
         this.enabled = enabled;
     }
+    
+    /**
+     * all args constructor.
+     * 
+     * @param id id
+     * @param name name
+     * @param config config
+     * @param role role
+     * @param enabled enabled
+     * @param sort sort
+     */
+    public PluginData(final String id, final String name, final String config, final String role, final Boolean enabled,
+                      final Integer sort) {
+        this.id = id;
+        this.name = name;
+        this.config = config;
+        this.role = role;
+        this.enabled = enabled;
+        this.sort = sort;
+    }
 
     /**
      * builder constructor.
@@ -70,6 +92,7 @@ public class PluginData {
         this.config = builder.config;
         this.role = builder.role;
         this.enabled = builder.enabled;
+        this.sort = builder.sort;
     }
 
     /**
@@ -163,6 +186,25 @@ public class PluginData {
     }
 
     /**
+     * get sort.
+     *
+     * @return enabled
+     */
+    public Integer getSort() {
+        return sort;
+    }
+
+
+    /**
+     * set sort.
+     * 
+     * @param sort sort value
+     */
+    public void setSort(final Integer sort) {
+        this.sort = sort;
+    }
+
+    /**
      * set enabled.
      *
      * @param enabled enabled
@@ -240,6 +282,11 @@ public class PluginData {
         private Boolean enabled;
 
         /**
+         * sort.
+         */
+        private Integer sort;
+
+        /**
          * no args constructor.
          */
         private Builder() {
@@ -306,6 +353,17 @@ public class PluginData {
          */
         public Builder enabled(final Boolean enabled) {
             this.enabled = enabled;
+            return this;
+        }
+
+        /**
+         * build sort.
+         *
+         * @param sort sort
+         * @return this
+         */
+        public Builder sort(final Integer sort) {
+            this.sort = sort;
             return this;
         }
     }

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java
@@ -26,10 +26,12 @@ import org.apache.shenyu.plugin.base.handler.PluginDataHandler;
 import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.lang.NonNull;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -41,7 +43,9 @@ public class CommonPluginDataSubscriber implements PluginDataSubscriber {
     private static final Logger LOG = LoggerFactory.getLogger(CommonPluginDataSubscriber.class);
     
     private final Map<String, PluginDataHandler> handlerMap;
-    
+
+    private ApplicationEventPublisher eventPublisher;
+
     /**
      * Instantiates a new Common plugin data subscriber.
      *
@@ -50,7 +54,19 @@ public class CommonPluginDataSubscriber implements PluginDataSubscriber {
     public CommonPluginDataSubscriber(final List<PluginDataHandler> pluginDataHandlerList) {
         this.handlerMap = pluginDataHandlerList.stream().collect(Collectors.toConcurrentMap(PluginDataHandler::pluginNamed, e -> e));
     }
-    
+
+    /**
+     * Instantiates a new Common plugin data subscriber.
+     *
+     * @param pluginDataHandlerList the plugin data handler list
+     * @param eventPublisher        eventPublisher is used to publish sort plugin event
+     */
+    public CommonPluginDataSubscriber(final List<PluginDataHandler> pluginDataHandlerList,
+                                      final ApplicationEventPublisher eventPublisher) {
+        this.handlerMap = pluginDataHandlerList.stream().collect(Collectors.toConcurrentMap(PluginDataHandler::pluginNamed, e -> e));
+        this.eventPublisher = eventPublisher;
+    }
+
     /**
      * Put extend plugin data handler.
      *
@@ -157,9 +173,12 @@ public class CommonPluginDataSubscriber implements PluginDataSubscriber {
     private <T> void updateCacheData(@NonNull final T data) {
         if (data instanceof PluginData) {
             PluginData pluginData = (PluginData) data;
+            PluginData oldPluginData = BaseDataCache.getInstance().obtainPluginData(pluginData.getName());
             BaseDataCache.getInstance().cachePluginData(pluginData);
             Optional.ofNullable(handlerMap.get(pluginData.getName()))
                     .ifPresent(handler -> handler.handlerPlugin(pluginData));
+
+            sortPluginIfOrderChange(oldPluginData, pluginData);
         } else if (data instanceof SelectorData) {
             SelectorData selectorData = (SelectorData) data;
             BaseDataCache.getInstance().cacheSelectData(selectorData);
@@ -174,7 +193,26 @@ public class CommonPluginDataSubscriber implements PluginDataSubscriber {
             
         }
     }
-    
+
+    /**
+     * judge need update plugin order.
+     *
+     * @param oldPluginData old pluginData
+     * @param pluginData    current pluginData
+     */
+    private void sortPluginIfOrderChange(final PluginData oldPluginData, final PluginData pluginData) {
+        if (eventPublisher == null) {
+            return;
+        }
+        if (pluginData.getSort() == null) {
+            return;
+        }
+        if (oldPluginData == null || oldPluginData.getSort() == null
+                || (!Objects.equals(oldPluginData.getSort(), pluginData.getSort()))) {
+            eventPublisher.publishEvent(new SortPluginEvent(new Object()));
+        }
+    }
+
     /**
      * remove cache data.
      *

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java
@@ -201,10 +201,7 @@ public class CommonPluginDataSubscriber implements PluginDataSubscriber {
      * @param pluginData    current pluginData
      */
     private void sortPluginIfOrderChange(final PluginData oldPluginData, final PluginData pluginData) {
-        if (eventPublisher == null) {
-            return;
-        }
-        if (pluginData.getSort() == null) {
+        if (Objects.isNull(eventPublisher) || Objects.isNull(pluginData.getSort())) {
             return;
         }
         if (oldPluginData == null || oldPluginData.getSort() == null

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java
@@ -204,7 +204,7 @@ public class CommonPluginDataSubscriber implements PluginDataSubscriber {
         if (Objects.isNull(eventPublisher) || Objects.isNull(pluginData.getSort())) {
             return;
         }
-        if (Objects.isNull(oldPluginData)||  Objects.isNull(oldPluginData.getSort())
+        if (Objects.isNull(oldPluginData) || Objects.isNull(oldPluginData.getSort())
                 || (!Objects.equals(oldPluginData.getSort(), pluginData.getSort()))) {
             eventPublisher.publishEvent(new SortPluginEvent(new Object()));
         }

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java
@@ -204,7 +204,7 @@ public class CommonPluginDataSubscriber implements PluginDataSubscriber {
         if (Objects.isNull(eventPublisher) || Objects.isNull(pluginData.getSort())) {
             return;
         }
-        if (oldPluginData == null || oldPluginData.getSort() == null
+        if (Objects.isNull(oldPluginData)||  Objects.isNull(oldPluginData.getSort())
                 || (!Objects.equals(oldPluginData.getSort(), pluginData.getSort()))) {
             eventPublisher.publishEvent(new SortPluginEvent(new Object()));
         }

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/SortPluginEvent.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/SortPluginEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.base.cache;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * event of sort plugin.
+ */
+public class SortPluginEvent extends ApplicationEvent {
+
+    public SortPluginEvent(final Object source) {
+        super(source);
+    }
+}

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/java/org/apache/shenyu/springboot/starter/gateway/ShenyuConfiguration.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/java/org/apache/shenyu/springboot/starter/gateway/ShenyuConfiguration.java
@@ -43,6 +43,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -111,11 +112,13 @@ public class ShenyuConfiguration {
      * Plugin data subscriber plugin data subscriber.
      *
      * @param pluginDataHandlerList the plugin data handler list
+     * @param eventPublisher event publisher
      * @return the plugin data subscriber
      */
     @Bean
-    public PluginDataSubscriber pluginDataSubscriber(final ObjectProvider<List<PluginDataHandler>> pluginDataHandlerList) {
-        return new CommonPluginDataSubscriber(pluginDataHandlerList.getIfAvailable(Collections::emptyList));
+    public PluginDataSubscriber pluginDataSubscriber(final ObjectProvider<List<PluginDataHandler>> pluginDataHandlerList,
+                                                     final ApplicationEventPublisher eventPublisher) {
+        return new CommonPluginDataSubscriber(pluginDataHandlerList.getIfAvailable(Collections::emptyList), eventPublisher);
     }
     
     /**

--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/PluginDataRefresh.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/PluginDataRefresh.java
@@ -19,7 +19,6 @@ package org.apache.shenyu.sync.data.http.refresh;
 
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
-import java.util.List;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.shenyu.common.dto.ConfigData;
 import org.apache.shenyu.common.dto.PluginData;
@@ -27,6 +26,8 @@ import org.apache.shenyu.common.enums.ConfigGroupEnum;
 import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * The type Plugin data refresh.

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/handler/ShenyuWebHandler.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/handler/ShenyuWebHandler.java
@@ -39,6 +39,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -130,11 +131,7 @@ public final class ShenyuWebHandler implements WebHandler, ApplicationListener<S
     private List<ShenyuPlugin> sortPlugins(final List<ShenyuPlugin> list) {
         Map<String, Integer> pluginSortMap = list.stream().collect(Collectors.toMap(ShenyuPlugin::named, plugin -> {
             PluginData pluginData = BaseDataCache.getInstance().obtainPluginData(plugin.named());
-            if (pluginData == null) {
-                return plugin.getOrder();
-            }
-            Integer sort = pluginData.getSort();
-            return sort == null ? plugin.getOrder() : sort;
+            return Optional.ofNullable(pluginData).map(PluginData::getSort).orElse(plugin.getOrder());
         }));
         list.sort(Comparator.comparingLong(plugin -> pluginSortMap.get(plugin.named())));
         return list;

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/handler/ShenyuWebHandler.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/handler/ShenyuWebHandler.java
@@ -18,11 +18,15 @@
 package org.apache.shenyu.web.handler;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.shenyu.common.config.ShenyuConfig;
+import org.apache.shenyu.common.dto.PluginData;
 import org.apache.shenyu.plugin.api.ShenyuPlugin;
 import org.apache.shenyu.plugin.api.ShenyuPluginChain;
-import org.apache.shenyu.common.config.ShenyuConfig;
+import org.apache.shenyu.plugin.base.cache.BaseDataCache;
+import org.apache.shenyu.plugin.base.cache.SortPluginEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
 import org.springframework.lang.NonNull;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebHandler;
@@ -30,18 +34,24 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
  * This is web handler request starter.
  */
-public final class ShenyuWebHandler implements WebHandler {
+public final class ShenyuWebHandler implements WebHandler, ApplicationListener<SortPluginEvent> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ShenyuWebHandler.class);
 
-    private final List<ShenyuPlugin> plugins;
+    /**
+     * this filed can not set to be final, because we should copyOnWrite to update plugins.
+     */
+    private List<ShenyuPlugin> plugins;
 
     private final boolean scheduled;
 
@@ -94,11 +104,40 @@ public final class ShenyuWebHandler implements WebHandler {
                 .filter(e -> plugins.stream().noneMatch(plugin -> plugin.named().equals(e.named())))
                 .collect(Collectors.toList());
         if (CollectionUtils.isNotEmpty(shenyuPlugins)) {
-            shenyuPlugins.forEach(plugin -> {
-                plugins.add(plugin);
-                LOG.info("shenyu auto add extends plugins:{}", plugin.named());
-            });
+            shenyuPlugins.forEach(plugin -> LOG.info("shenyu auto add extends plugins:{}", plugin.named()));
+            shenyuPlugins.addAll(plugins);
+            this.plugins = sortPlugins(shenyuPlugins);
         }
+    }
+    
+    /**
+     * listen sort plugin event and sort plugin.
+     *
+     * @param event sort plugin event
+     */
+    @Override
+    public void onApplicationEvent(final SortPluginEvent event) {
+        // copy a new one, or there will be concurrency problems
+        this.plugins = sortPlugins(new ArrayList<>(plugins));
+    }
+
+    /**
+     * sort plugins.
+     *
+     * @param list list of plugin
+     * @return sorted list
+     */
+    private List<ShenyuPlugin> sortPlugins(final List<ShenyuPlugin> list) {
+        Map<String, Integer> pluginSortMap = list.stream().collect(Collectors.toMap(ShenyuPlugin::named, plugin -> {
+            PluginData pluginData = BaseDataCache.getInstance().obtainPluginData(plugin.named());
+            if (pluginData == null) {
+                return plugin.getOrder();
+            }
+            Integer sort = pluginData.getSort();
+            return sort == null ? plugin.getOrder() : sort;
+        }));
+        list.sort(Comparator.comparingLong(plugin -> pluginSortMap.get(plugin.named())));
+        return list;
     }
 
     private static class DefaultShenyuPluginChain implements ShenyuPluginChain {


### PR DESCRIPTION
Synchronize sorting of plugins. #2892 
### test case:

1. update plugin sort in admin, the order of ShenyuWebHandler’s plugins have changed.
2. After the plug-in sequence changes. After restart, the sequence is the same.
3. When the plugins of ShenyuWebhandler changes, the ongoing requests will not be affected.

### testing procedure：
1. admin use mysql and run admin.
2. Run gateway ShenyuBootstrapApplication.
3. Run test demo of ShenyuTestHttpApplication.
4. now send a request to gateway.
  `curl --location --request POST 'http://localhost:9195/http/order/save?a=1' \
  --header 'Content-Type: application/json' \
  --header 'Cookie: JSESSIONID=302C524F06306C42AE4DB7A7D9716BF4' \
  --data-raw '{
      "id":666,
      "name": "hello world"
  }'`
  debug ShenyuWebHander handler method, we find the sign plugin is before jwt plugin.
5. now we change jwt plugin order from 20 to 35. 
6. now repeat step 4. we can find the sign plugin is after jwt plugin.
7. now we test case 2. stop and restart gateway ShenyuBootstrapApplication.
8. now repeat step 4. we can find the sign plugin is after jwt plugin.This indicates that the plug-in sequence has a persistent effect.
9. For concurrent modification of plug-in order, we use **copy on write**.

### Event notification mechanism
**problem：**
   the module of shenyu-plugin not dependent shenyu-web, so when happen sort plugin event,we can not operate directly shenyuWebHandler。
**terms of settlement:**
   I used spring event publish function. 

