### PR TITLE
[type: bug]The trouble of big data in Websocket. #2891

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/WebsocketSyncProperties.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/WebsocketSyncProperties.java
@@ -31,6 +31,11 @@ public class WebsocketSyncProperties {
     private boolean enabled = true;
 
     /**
+     * default is 8192.
+     */
+    private int messageMaxSize;
+
+    /**
      * Gets the value of enabled.
      *
      * @return the value of enabled
@@ -46,5 +51,23 @@ public class WebsocketSyncProperties {
      */
     public void setEnabled(final boolean enabled) {
         this.enabled = enabled;
+    }
+
+    /**
+     * get messageMaxSize.
+     *
+     * @return messageMaxSize
+     */
+    public int getMessageMaxSize() {
+        return messageMaxSize;
+    }
+
+    /**
+     * set messageMaxSize.
+     *
+     * @param messageMaxSize messageMaxSize
+     */
+    public void setMessageMaxSize(final int messageMaxSize) {
+        this.messageMaxSize = messageMaxSize;
     }
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/websocket/WebsocketCollector.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/websocket/WebsocketCollector.java
@@ -60,7 +60,8 @@ public class WebsocketCollector {
      */
     @OnOpen
     public void onOpen(final Session session) {
-        LOG.info("websocket on client[{}] open successful....", getClientIp(session));
+        LOG.info("websocket on client[{}] open successful,maxTextMessageBufferSize:{}",
+                getClientIp(session), session.getMaxTextMessageBufferSize());
         SESSION_SET.add(session);
     }
     

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/websocket/WebsocketConfigurator.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/websocket/WebsocketConfigurator.java
@@ -17,22 +17,49 @@
 
 package org.apache.shenyu.admin.listener.websocket;
 
+import org.apache.shenyu.admin.config.properties.WebsocketSyncProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpSession;
 import javax.websocket.HandshakeResponse;
 import javax.websocket.server.HandshakeRequest;
 import javax.websocket.server.ServerEndpointConfig;
+
+import static org.apache.tomcat.websocket.server.Constants.BINARY_BUFFER_SIZE_SERVLET_CONTEXT_INIT_PARAM;
+import static org.apache.tomcat.websocket.server.Constants.TEXT_BUFFER_SIZE_SERVLET_CONTEXT_INIT_PARAM;
 
 /**
  * The Websocket configurator.
  *
  * @since 2.0.0
  */
-public class WebsocketConfigurator extends ServerEndpointConfig.Configurator {
+@ConditionalOnProperty(name = "shenyu.sync.websocket.enabled", havingValue = "true", matchIfMissing = true)
+@Configuration
+public class WebsocketConfigurator extends ServerEndpointConfig.Configurator implements ServletContextInitializer {
+
+    @Autowired
+    private WebsocketSyncProperties websocketSyncProperties;
 
     @Override
     public void modifyHandshake(final ServerEndpointConfig sec, final HandshakeRequest request, final HandshakeResponse response) {
         HttpSession httpSession = (HttpSession) request.getHttpSession();
         sec.getUserProperties().put(WebsocketListener.CLIENT_IP_NAME, httpSession.getAttribute(WebsocketListener.CLIENT_IP_NAME));
         super.modifyHandshake(sec, request, response);
+    }
+
+    @Override
+    public void onStartup(final ServletContext servletContext) throws ServletException {
+        int messageMaxSize = websocketSyncProperties.getMessageMaxSize();
+        if (messageMaxSize > 0) {
+            servletContext.setInitParameter(TEXT_BUFFER_SIZE_SERVLET_CONTEXT_INIT_PARAM,
+                    String.valueOf(messageMaxSize));
+            servletContext.setInitParameter(BINARY_BUFFER_SIZE_SERVLET_CONTEXT_INIT_PARAM,
+                    String.valueOf(messageMaxSize));
+        }
     }
 }

--- a/shenyu-admin/src/main/resources/application.yml
+++ b/shenyu-admin/src/main/resources/application.yml
@@ -45,6 +45,7 @@ shenyu:
   sync:
     websocket:
       enabled: true
+      messageMaxSize: 10240
 #      zookeeper:
 #        url: localhost:2181
 #        sessionTimeout: 5000


### PR DESCRIPTION
1. config admin prop:   shenyu.sync.websocket.messageMaxSize=**10240**
2. setup admin:run ShenyuAdminBootstrap
3. setup gateway: run ShenyuBootstrapApplication
4. you can see: admin log output: websocket on client[127.0.0.1] open successful,maxTextMessageBufferSize:**10240** 

