### PR TITLE
[type:refactor][ISSUE #2916] set ribbon default ServerListRefreshInterval from 30s to 10s

### DIFF
--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-springcloud/src/main/java/org/apache/shenyu/springboot/starter/plugin/springcloud/SpringCloudPluginConfiguration.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-springcloud/src/main/java/org/apache/shenyu/springboot/starter/plugin/springcloud/SpringCloudPluginConfiguration.java
@@ -17,7 +17,11 @@
 
 package org.apache.shenyu.springboot.starter.plugin.springcloud;
 
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.IRule;
+import com.netflix.loadbalancer.PollingServerListUpdater;
+import com.netflix.loadbalancer.ServerListUpdater;
 import org.apache.shenyu.common.constant.Constants;
 import org.apache.shenyu.plugin.api.ShenyuPlugin;
 import org.apache.shenyu.plugin.api.context.ShenyuContextDecorator;
@@ -31,6 +35,7 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClientSpecification;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * The type Spring cloud plugin configuration.
@@ -84,6 +89,13 @@ public class SpringCloudPluginConfiguration {
         @Bean
         public IRule ribbonRule() {
             return new LoadBalanceRule();
+        }
+
+        @Lazy
+        @Bean
+        public ServerListUpdater ribbonServerListUpdater(final IClientConfig config) {
+            config.set(CommonClientConfigKey.ServerListRefreshInterval, 10000);
+            return new PollingServerListUpdater(config);
         }
     }
 


### PR DESCRIPTION
see https://github.com/apache/incubator-shenyu/issues/2916.

You can follow these steps to verify whether the results are correct :
1. run `ShenyuAdminBootstrap`;
2. turn on `SpringCloudPlugin` in `shenyu-admin`;
3. run `EurekaServerApplication`;
4. run `ShenyuTestSpringCloudApplication`;
5. enable `Ribbon` then run `ShenyuBootstrapApplication`;
6. run `spring-cloud-test-api.http`.