### PR TITLE
fix fallbackUri only works for APIs in `shenyu-bootstrap` in resilience4j plugin issue

### DIFF
--- a/shenyu-plugin/shenyu-plugin-resilience4j/src/main/java/org/apache/shenyu/plugin/resilience4j/executor/Executor.java
+++ b/shenyu-plugin/shenyu-plugin-resilience4j/src/main/java/org/apache/shenyu/plugin/resilience4j/executor/Executor.java
@@ -17,23 +17,22 @@
 
 package org.apache.shenyu.plugin.resilience4j.executor;
 
+import com.google.common.base.Strings;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
 import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
-import org.apache.shenyu.plugin.api.utils.SpringBeanUtils;
 import org.apache.shenyu.plugin.api.utils.WebFluxResultUtils;
 import org.apache.shenyu.common.utils.UriUtils;
 import org.apache.shenyu.plugin.resilience4j.Resilience4JPlugin;
 import org.apache.shenyu.plugin.resilience4j.conf.Resilience4JConf;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.web.reactive.DispatcherHandler;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
-import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
@@ -65,10 +64,27 @@ public interface Executor {
         if (StringUtils.isBlank(uri)) {
             return withoutFallback(exchange, t);
         }
-        DispatcherHandler dispatcherHandler = SpringBeanUtils.getInstance().getBean(DispatcherHandler.class);
-        ServerHttpRequest request = exchange.getRequest().mutate().uri(Objects.requireNonNull(UriUtils.createUri(uri))).build();
-        ServerWebExchange mutated = exchange.mutate().request(request).build();
-        return dispatcherHandler.handle(mutated);
+
+        ServerHttpResponse response = exchange.getResponse();
+        ServerHttpRequest request = exchange.getRequest();
+        // avoid redirect loop, return error.
+        boolean isSameUri;
+        if (uri.startsWith("https") || uri.startsWith("http")) {
+            isSameUri = request.getURI().toString().equals(uri);
+        } else {
+            String params = Strings.isNullOrEmpty(request.getURI().getQuery()) ? "" : request.getURI().getQuery();
+            String reqQueryWithParams = request.getURI().getPath() + params;
+            isSameUri = reqQueryWithParams.equals(uri);
+        }
+
+        if (isSameUri) {
+            return withoutFallback(exchange, t);
+        }
+
+        // redirect to fallback uri.
+        response.setStatusCode(HttpStatus.FOUND);
+        response.getHeaders().setLocation(UriUtils.createUri(uri));
+        return Mono.empty();
     }
 
     /**


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo

For #2937 , 
- fixed the redirect issue.
- verified if the `fallbackUri` is the same with request uri to avoid redirect loop.

After this PR, it will redirect to the real `fallbackUri` set in `admin` portal.
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/11908658/155685450-379a4207-7446-44f1-b3f5-4098431b8b3e.png">


<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
