### PR TITLE
[ISSUE #2966] support redirecting to URIs outside of bootstrap and refactoring code.

### DIFF
--- a/shenyu-common/src/main/java/org/apache/shenyu/common/utils/UriUtils.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/utils/UriUtils.java
@@ -20,6 +20,7 @@ package org.apache.shenyu.common.utils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.net.URI;
+import java.util.Objects;
 
 /**
  * uri util.
@@ -59,5 +60,19 @@ public class UriUtils {
      */
     public static String removePrefix(final String name) {
         return name.startsWith(PRE_FIX) ? name.substring(1) : name;
+    }
+
+    /**
+     * Get the path of uri with parameters.
+     *
+     * @param uri the uri.
+     * @return absolute uri string with parameters.
+     */
+    public static String getPathWithParams(final URI uri) {
+        if (Objects.isNull(uri)) {
+            return StringUtils.EMPTY;
+        }
+        String params = StringUtils.isEmpty(uri.getQuery()) ? "" : "?" + uri.getQuery();
+        return uri.getPath() + params;
     }
 }

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/utils/UriUtilsTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/utils/UriUtilsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.common.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test cases for UriUtils.
+ */
+class UriUtilsTest {
+
+    @Test
+    void createUri() {
+        URI uri = UriUtils.createUri("https://example.com");
+        assertEquals("https://example.com", uri.toString());
+
+        uri = UriUtils.createUri(null);
+        assertNull(uri);
+
+        uri = UriUtils.createUri("");
+        assertNull(uri);
+    }
+
+    @Test
+    void repairData() {
+        String ret = UriUtils.repairData("http");
+        assertEquals("/http", ret);
+
+        ret = UriUtils.repairData("/http");
+        assertEquals("/http", ret);
+    }
+
+    @Test
+    void removePrefix() {
+        String ret = UriUtils.removePrefix("http");
+        assertEquals("http", ret);
+
+        ret = UriUtils.removePrefix("/http");
+        assertEquals("http", ret);
+    }
+
+    @Test
+    void getPathWithParams() {
+        URI uri = UriUtils.createUri("https://example.com");
+        assertNotNull(uri);
+        String ret = UriUtils.getPathWithParams(uri);
+        assertEquals("", ret);
+
+        uri = UriUtils.createUri("https://example.com/path");
+        assertNotNull(uri);
+        ret = UriUtils.getPathWithParams(uri);
+        assertEquals("/path", ret);
+
+        uri = UriUtils.createUri("https://example.com/path?key=val");
+        assertNotNull(uri);
+        ret = UriUtils.getPathWithParams(uri);
+        assertEquals("/path?key=val", ret);
+
+        uri = UriUtils.createUri("/path?key=val");
+        assertNotNull(uri);
+        ret = UriUtils.getPathWithParams(uri);
+        assertEquals("/path?key=val", ret);
+    }
+}

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/utils/UriUtilsTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/utils/UriUtilsTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * Test cases for UriUtils.
  */
-class UriUtilsTest {
+public final class UriUtilsTest {
 
     @Test
     void createUri() {

--- a/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/fallback/FallbackHandlerTest.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/fallback/FallbackHandlerTest.java
@@ -69,7 +69,7 @@ public final class FallbackHandlerTest {
      */
     @Test
     public void generateErrorTest() {
-        StepVerifier.create(testFallbackHandler.generateError(exchange, new RuntimeException())).expectSubscription().verifyComplete();
+        StepVerifier.create(testFallbackHandler.withoutFallback(exchange, new RuntimeException())).expectSubscription().verifyComplete();
     }
 
     /**
@@ -83,7 +83,7 @@ public final class FallbackHandlerTest {
 
     static class TestFallbackHandler implements FallbackHandler {
         @Override
-        public Mono<Void> generateError(final ServerWebExchange exchange, final Throwable throwable) {
+        public Mono<Void> withoutFallback(final ServerWebExchange exchange, final Throwable throwable) {
             return Mono.empty();
         }
     }

--- a/shenyu-plugin/shenyu-plugin-resilience4j/src/main/java/org/apache/shenyu/plugin/resilience4j/Resilience4JPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-resilience4j/src/main/java/org/apache/shenyu/plugin/resilience4j/Resilience4JPlugin.java
@@ -22,6 +22,7 @@ import org.apache.shenyu.common.dto.RuleData;
 import org.apache.shenyu.common.dto.SelectorData;
 import org.apache.shenyu.common.dto.convert.rule.Resilience4JHandle;
 import org.apache.shenyu.common.enums.PluginEnum;
+import org.apache.shenyu.common.utils.UriUtils;
 import org.apache.shenyu.plugin.api.ShenyuPluginChain;
 import org.apache.shenyu.plugin.api.context.ShenyuContext;
 import org.apache.shenyu.plugin.base.AbstractShenyuPlugin;
@@ -87,7 +88,7 @@ public class Resilience4JPlugin extends AbstractShenyuPlugin {
 
     private Function<Throwable, Mono<Void>> fallback(final Executor executor,
                                                      final ServerWebExchange exchange, final String uri) {
-        return throwable -> executor.fallback(exchange, uri, throwable);
+        return throwable -> executor.fallback(exchange, UriUtils.createUri(uri), throwable);
     }
 
     @Override

--- a/shenyu-plugin/shenyu-plugin-resilience4j/src/main/java/org/apache/shenyu/plugin/resilience4j/executor/Executor.java
+++ b/shenyu-plugin/shenyu-plugin-resilience4j/src/main/java/org/apache/shenyu/plugin/resilience4j/executor/Executor.java
@@ -17,19 +17,15 @@
 
 package org.apache.shenyu.plugin.resilience4j.executor;
 
-import com.google.common.base.Strings;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
 import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
 import org.apache.shenyu.plugin.api.utils.WebFluxResultUtils;
-import org.apache.shenyu.common.utils.UriUtils;
+import org.apache.shenyu.plugin.base.fallback.FallbackHandler;
 import org.apache.shenyu.plugin.resilience4j.Resilience4JPlugin;
 import org.apache.shenyu.plugin.resilience4j.conf.Resilience4JConf;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -39,7 +35,7 @@ import java.util.function.Function;
 /**
  * Executor.
  */
-public interface Executor {
+public interface Executor extends FallbackHandler {
 
     /**
      * resilience run.
@@ -53,47 +49,13 @@ public interface Executor {
     <T> Mono<T> run(Mono<T> toRun, Function<Throwable, Mono<T>> fallback, Resilience4JConf conf);
 
     /**
-     * do fallback.
+     * do fallback with not fallback method.
      *
-     * @param exchange the exchange
-     * @param uri      the uri
-     * @param t        the t
-     * @return Mono
-     */
-    default Mono<Void> fallback(ServerWebExchange exchange, String uri, Throwable t) {
-        if (StringUtils.isBlank(uri)) {
-            return withoutFallback(exchange, t);
-        }
-
-        ServerHttpResponse response = exchange.getResponse();
-        ServerHttpRequest request = exchange.getRequest();
-        // avoid redirect loop, return error.
-        boolean isSameUri;
-        if (uri.startsWith("https") || uri.startsWith("http")) {
-            isSameUri = request.getURI().toString().equals(uri);
-        } else {
-            String params = Strings.isNullOrEmpty(request.getURI().getQuery()) ? "" : request.getURI().getQuery();
-            String reqQueryWithParams = request.getURI().getPath() + params;
-            isSameUri = reqQueryWithParams.equals(uri);
-        }
-
-        if (isSameUri) {
-            return withoutFallback(exchange, t);
-        }
-
-        // redirect to fallback uri.
-        response.setStatusCode(HttpStatus.FOUND);
-        response.getHeaders().setLocation(UriUtils.createUri(uri));
-        return Mono.empty();
-    }
-
-    /**
-     * do fallback with not  fallback method.
-     *
-     * @param exchange the exchange
+     * @param exchange  the exchange
      * @param throwable the throwable
      * @return Mono
      */
+    @Override
     default Mono<Void> withoutFallback(ServerWebExchange exchange, Throwable throwable) {
         Object error;
         if (throwable instanceof TimeoutException) {

--- a/shenyu-plugin/shenyu-plugin-resilience4j/src/test/java/org/apache/shenyu/plugin/resilience4j/executor/CombinedExecutorTest.java
+++ b/shenyu-plugin/shenyu-plugin-resilience4j/src/test/java/org/apache/shenyu/plugin/resilience4j/executor/CombinedExecutorTest.java
@@ -20,6 +20,7 @@ package org.apache.shenyu.plugin.resilience4j.executor;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
+import org.apache.shenyu.common.utils.UriUtils;
 import org.apache.shenyu.plugin.resilience4j.conf.Resilience4JConf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,7 +88,7 @@ public final class CombinedExecutorTest {
 
         ServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("localhost").build());
 
-        StepVerifier.create(combinedExecutor.run(Mono.error(new RuntimeException()), t -> combinedExecutor.fallback(exchange, "https://example.com", t),
+        StepVerifier.create(combinedExecutor.run(Mono.error(new RuntimeException()), t -> combinedExecutor.fallback(exchange, UriUtils.createUri("https://example.com"), t),
                         conf))
                 .expectSubscription()
                 .expectComplete()

--- a/shenyu-plugin/shenyu-plugin-sentinel/src/main/java/org/apache/shenyu/plugin/sentinel/fallback/SentinelFallbackHandler.java
+++ b/shenyu-plugin/shenyu-plugin-sentinel/src/main/java/org/apache/shenyu/plugin/sentinel/fallback/SentinelFallbackHandler.java
@@ -34,7 +34,7 @@ import reactor.core.publisher.Mono;
 public class SentinelFallbackHandler implements FallbackHandler {
 
     @Override
-    public Mono<Void> generateError(final ServerWebExchange exchange, final Throwable throwable) {
+    public Mono<Void> withoutFallback(final ServerWebExchange exchange, final Throwable throwable) {
         Object error;
         if (throwable instanceof DegradeException) {
             exchange.getResponse().setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/shenyu-plugin/shenyu-plugin-sentinel/src/test/java/org/apache/shenyu/plugin/sentinel/fallback/SentinelFallbackHandlerTest.java
+++ b/shenyu-plugin/shenyu-plugin-sentinel/src/test/java/org/apache/shenyu/plugin/sentinel/fallback/SentinelFallbackHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.shenyu.plugin.sentinel.fallback;
 import com.alibaba.csp.sentinel.slots.block.authority.AuthorityException;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeException;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowException;
+import org.apache.shenyu.common.utils.UriUtils;
 import org.apache.shenyu.plugin.api.result.DefaultShenyuResult;
 import org.apache.shenyu.plugin.api.result.ShenyuResult;
 import org.apache.shenyu.plugin.api.utils.SpringBeanUtils;
@@ -30,13 +31,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.test.StepVerifier;
 
 import java.net.InetSocketAddress;
+import java.util.Objects;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,7 +69,7 @@ public final class SentinelFallbackHandlerTest {
      */
     @Test
     public void testDegradeException() {
-        StepVerifier.create(fallbackHandler.generateError(exchange, new DegradeException("Sentinel"))).expectSubscription().verifyComplete();
+        StepVerifier.create(fallbackHandler.withoutFallback(exchange, new DegradeException("Sentinel"))).expectSubscription().verifyComplete();
     }
 
     /**
@@ -73,7 +77,7 @@ public final class SentinelFallbackHandlerTest {
      */
     @Test
     public void testFlowException() {
-        StepVerifier.create(fallbackHandler.generateError(exchange, new FlowException(""))).expectSubscription().verifyComplete();
+        StepVerifier.create(fallbackHandler.withoutFallback(exchange, new FlowException(""))).expectSubscription().verifyComplete();
     }
 
     /**
@@ -81,7 +85,7 @@ public final class SentinelFallbackHandlerTest {
      */
     @Test
     public void testBlockException() {
-        StepVerifier.create(fallbackHandler.generateError(exchange, new AuthorityException("Sentinel"))).expectSubscription().verifyComplete();
+        StepVerifier.create(fallbackHandler.withoutFallback(exchange, new AuthorityException("Sentinel"))).expectSubscription().verifyComplete();
     }
 
     /**
@@ -89,6 +93,13 @@ public final class SentinelFallbackHandlerTest {
      */
     @Test
     public void testRuntimeException() {
-        StepVerifier.create(fallbackHandler.generateError(exchange, new RuntimeException())).expectSubscription().verifyError();
+        StepVerifier.create(fallbackHandler.withoutFallback(exchange, new RuntimeException())).expectSubscription().verifyError();
+    }
+
+    @Test
+    public void testFallbackUri() {
+        StepVerifier.create(fallbackHandler.fallback(exchange, UriUtils.createUri("https://example.com"), new RuntimeException())).expectSubscription().verifyComplete();
+        assertEquals(HttpStatus.FOUND, exchange.getResponse().getStatusCode());
+        assertEquals("https://example.com", Objects.requireNonNull(exchange.getResponse().getHeaders().getLocation()).toString());
     }
 }


### PR DESCRIPTION
…to reduce dup code

// Describe your PR here; eg. Fixes #issueNo

For #2966 . Finished below items. After this change, the fallback URI in `sentinel` plugin can support redirecting to external URIs.

- support redirect to URIs not in bootstrap.
- refactor to reduce dup codes in resilience4j and sentinel plugin.
- add related unit test.
- add related integrated test.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
