### PR TITLE
[type:fix] fix CVE-2021-41303

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <wiremock.version>2.18.0</wiremock.version>
         <zookeeper.version>3.5.6</zookeeper.version>
         <zkclient.version>0.10</zkclient.version>
-        <shiro.version>1.7.0</shiro.version>
+        <shiro.version>1.8.0</shiro.version>
         <jwt.version>3.12.0</jwt.version>
         <motan.version>1.1.9</motan.version>
         <spring-boot.version>2.2.2.RELEASE</spring-boot.version>


### PR DESCRIPTION
https://www.mail-archive.com/announce@apache.org/msg06740.html

We should update to Apache Shiro 1.8.0.