### PR TITLE
[ISSUE #2931]The URL returned by default after adding the hystrix and resilience4j

### DIFF
--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/result/ShenyuResultWrap.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/result/ShenyuResultWrap.java
@@ -54,6 +54,17 @@ public final class ShenyuResultWrap {
     /**
      * Error object.
      *
+     * @param shenyuResult    the shenyuResult
+     * @param object  the object
+     * @return the object
+     */
+    public static Object error(final ShenyuResultEnum shenyuResult, final Object object) {
+        return shenyuResult().error(shenyuResult.getCode(), shenyuResult.getMsg(), object);
+    }
+
+    /**
+     * Error object.
+     *
      * @param exchange the exchange
      * @param code    the code
      * @param message the message

--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/result/ShenyuResultWrap.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/result/ShenyuResultWrap.java
@@ -54,18 +54,6 @@ public final class ShenyuResultWrap {
     /**
      * Error object.
      *
-     * @param code    the code
-     * @param message the message
-     * @param object  the object
-     * @return the object
-     */
-    public static Object error(final int code, final String message, final Object object) {
-        return SpringBeanUtils.getInstance().getBean(ShenyuResult.class).error(code, message, object);
-    }
-
-    /**
-     * Error object.
-     *
      * @param exchange the exchange
      * @param code    the code
      * @param message the message

--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/result/ShenyuResultWrap.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/result/ShenyuResultWrap.java
@@ -54,6 +54,18 @@ public final class ShenyuResultWrap {
     /**
      * Error object.
      *
+     * @param code    the code
+     * @param message the message
+     * @param object  the object
+     * @return the object
+     */
+    public static Object error(final int code, final String message, final Object object) {
+        return SpringBeanUtils.getInstance().getBean(ShenyuResult.class).error(code, message, object);
+    }
+
+    /**
+     * Error object.
+     *
      * @param exchange the exchange
      * @param code    the code
      * @param message the message

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
@@ -19,8 +19,6 @@ package org.apache.shenyu.web.fallback;
 
 import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
 import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,18 +30,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/fallback")
 public class DefaultFallbackController {
     /**
-     * logger.
-     */
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultFallbackController.class);
-
-    /**
      * default fallback for hystrix.
      *
      * @return the shenyu result
      */
     @GetMapping("/hystrix")
     public Object hystrixPluginFallback() {
-        return ShenyuResultWrap.error(null, ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getMsg(), null);
+        return ShenyuResultWrap.error(null, ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK, null);
     }
 
     /**
@@ -53,6 +46,6 @@ public class DefaultFallbackController {
      */
     @GetMapping("/resilience4j")
     public Object resilience4jFallBack() {
-        return ShenyuResultWrap.error(null, ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getMsg(), null);
+        return ShenyuResultWrap.error(null, ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK, null);
     }
 }

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
@@ -43,7 +43,6 @@ public class DefaultFallbackController {
      */
     @GetMapping("/hystrix")
     public Object hystrixPluginFallback() {
-        LOG.error("the default fallback for hystrix");
         return ShenyuResultWrap.error(ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getMsg(), null);
     }
 
@@ -54,7 +53,6 @@ public class DefaultFallbackController {
      */
     @GetMapping("/resilience4j")
     public Object resilience4jFallBack() {
-        LOG.error("the default fallback for resilience4j");
         return ShenyuResultWrap.error(ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getMsg(), null);
     }
 }

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
@@ -43,7 +43,7 @@ public class DefaultFallbackController {
      */
     @GetMapping("/hystrix")
     public Object hystrixPluginFallback() {
-        return ShenyuResultWrap.error(ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getMsg(), null);
+        return ShenyuResultWrap.error(null, ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getMsg(), null);
     }
 
     /**
@@ -53,6 +53,6 @@ public class DefaultFallbackController {
      */
     @GetMapping("/resilience4j")
     public Object resilience4jFallBack() {
-        return ShenyuResultWrap.error(ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getMsg(), null);
+        return ShenyuResultWrap.error(null,ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getMsg(), null);
     }
 }

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.web.fallback;
+
+import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
+import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The default fallback for hystrix plugin and resilience4j plugin.
+ */
+@RestController
+@RequestMapping("/fallback")
+public class DefaultFallbackController {
+    /**
+     * logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultFallbackController.class);
+
+    /**
+     * default fallback for hystrix.
+     *
+     * @return the shenyu result
+     */
+    @GetMapping("/hystrix")
+    public Object hystrixPluginFallback() {
+        LOG.error("the default fallback for hystrix");
+        return ShenyuResultWrap.error(ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK.getMsg(), null);
+    }
+
+    /**
+     * default fallback for resilience4j.
+     *
+     * @return the shenyu result
+     */
+    @GetMapping("/resilience4j")
+    public Object resilience4jFallBack() {
+        LOG.error("the default fallback for resilience4j");
+        return ShenyuResultWrap.error(ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getMsg(), null);
+    }
+}

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
@@ -36,7 +36,7 @@ public class DefaultFallbackController {
      */
     @GetMapping("/hystrix")
     public Object hystrixPluginFallback() {
-        return ShenyuResultWrap.error(null, ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK, null);
+        return ShenyuResultWrap.error(ShenyuResultEnum.HYSTRIX_PLUGIN_FALLBACK, null);
     }
 
     /**
@@ -46,6 +46,6 @@ public class DefaultFallbackController {
      */
     @GetMapping("/resilience4j")
     public Object resilience4jFallBack() {
-        return ShenyuResultWrap.error(null, ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK, null);
+        return ShenyuResultWrap.error(ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK, null);
     }
 }

--- a/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
+++ b/shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java
@@ -53,6 +53,6 @@ public class DefaultFallbackController {
      */
     @GetMapping("/resilience4j")
     public Object resilience4jFallBack() {
-        return ShenyuResultWrap.error(null,ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getMsg(), null);
+        return ShenyuResultWrap.error(null, ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getCode(), ShenyuResultEnum.RESILIENCE4J_PLUGIN_FALLBACK.getMsg(), null);
     }
 }


### PR DESCRIPTION
part of #2990 supplement

In the previous code, the system can only be blown, but it cannot achieve fallback  


```
2022-03-11 15:21:19 [boundedElastic-1] ERROR org.apache.shenyu.plugin.hystrix.HystrixPlugin - hystrix execute have circuitBreaker is Open! groupKey:/http,commandKey:/test/waf/pass
2022-03-11 15:21:19 [boundedElastic-3] ERROR org.apache.shenyu.plugin.hystrix.HystrixPlugin - hystrix execute have circuitBreaker is Open! groupKey:/http,commandKey:/test/waf/pass
2022-03-11 15:21:19 [boundedElastic-1] INFO  org.apache.shenyu.plugin.base.AbstractShenyuPlugin - hystrix selector success match , selector name :testHy
2022-03-11 15:21:19 [boundedElastic-3] INFO  org.apache.shenyu.plugin.base.AbstractShenyuPlugin - hystrix selector success match , selector name :testHy
2022-03-11 15:21:19 [boundedElastic-1] INFO  org.apache.shenyu.plugin.base.AbstractShenyuPlugin - hystrix rule success match , rule name :hyRules
2022-03-11 15:21:19 [boundedElastic-3] INFO  org.apache.shenyu.plugin.base.AbstractShenyuPlugin - hystrix rule success match , rule name :hyRules
```

After adding the url returned by default, the system can normally prompt the url of fuse and failure to return.

```
2022-03-11 15:21:19 [boundedElastic-3] ERROR org.apache.shenyu.web.fallback.DefaultFallbackController - the default fallback for hystrix
2022-03-11 15:21:19 [boundedElastic-1] ERROR org.apache.shenyu.web.fallback.DefaultFallbackController - the default fallback for hystrix
2022-03-11 15:21:19 [boundedElastic-3] ERROR org.apache.shenyu.plugin.hystrix.HystrixPlugin - hystrix execute have circuitBreaker is Open! groupKey:/http,commandKey:/test/waf/pass
2022-03-11 15:21:19 [boundedElastic-1] ERROR org.apache.shenyu.plugin.hystrix.HystrixPlugin - hystrix execute have circuitBreaker is Open! groupKey:/http,commandKey:/test/waf/pass
```