### PR TITLE
[ISSUE #2840] fix NPE or wesocket proxy fails when the contextpath pl…

### DIFF
--- a/shenyu-plugin/shenyu-plugin-websocket/src/main/java/org/apache/shenyu/plugin/websocket/WebSocketPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-websocket/src/main/java/org/apache/shenyu/plugin/websocket/WebSocketPlugin.java
@@ -109,7 +109,7 @@ public class WebSocketPlugin extends AbstractShenyuPlugin {
         if (StringUtils.isEmpty(protocol)) {
             protocol = "ws://";
         }
-        String path = shenyuContext.getMethod();
+        String path = !StringUtils.isEmpty(shenyuContext.getRealUrl()) ? shenyuContext.getRealUrl() : shenyuContext.getMethod();
         if (StringUtils.hasText(exchange.getRequest().getURI().getQuery())) {
             path = String.join("?", path, RequestQueryCodecUtil.getCodecQuery(exchange));
         }


### PR DESCRIPTION
If the contextpath plug-in is opened and the URL does not contain contextpath, will throw NPE. If url contains contextpath, unable to access back-end microservices.