### PR TITLE
[type: refactor] Change mysql image to mariadb in docker-compose yaml

### DIFF
--- a/shenyu-dist/shenyu-docker-compose-dist/src/main/resources/stand-alone-mysql/docker-compose.yaml
+++ b/shenyu-dist/shenyu-docker-compose-dist/src/main/resources/stand-alone-mysql/docker-compose.yaml
@@ -51,7 +51,7 @@ services:
       db:
         condition: service_healthy
   db:
-    image: docker.io/mysql:5.7
+    image: mariadb:10.2.41
     container_name: db
     environment:
       MYSQL_ROOT_PASSWORD: xyzj1a2y3


### PR DESCRIPTION
About #3166 #3163

The docker image of `mysql` can't support arm arch, let's change to `mariadb`, which is compatible with mysql and support multi-arch.