### PR TITLE
[ISSUE #2969] fix isFull not working in springcloud and http application

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractContextPathRegisterService.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractContextPathRegisterService.java
@@ -17,7 +17,7 @@
 
 package org.apache.shenyu.admin.service.register;
 
-import org.apache.shenyu.admin.utils.PathUtils;
+import org.apache.shenyu.common.utils.PathUtils;
 import org.apache.shenyu.common.dto.convert.rule.impl.ContextMappingRuleHandle;
 import org.apache.shenyu.common.enums.PluginEnum;
 import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java
@@ -28,7 +28,7 @@ import org.apache.shenyu.admin.service.RuleService;
 import org.apache.shenyu.admin.service.SelectorService;
 import org.apache.shenyu.admin.service.impl.UpstreamCheckService;
 import org.apache.shenyu.admin.utils.CommonUpstreamUtils;
-import org.apache.shenyu.admin.utils.PathUtils;
+import org.apache.shenyu.common.utils.PathUtils;
 import org.apache.shenyu.admin.utils.ShenyuResultMessage;
 import org.apache.shenyu.common.dto.SelectorData;
 import org.apache.shenyu.common.dto.convert.selector.CommonUpstream;

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImpl.java
@@ -23,7 +23,7 @@ import org.apache.shenyu.admin.model.entity.SelectorDO;
 import org.apache.shenyu.admin.service.MetaDataService;
 import org.apache.shenyu.admin.service.converter.SpringCloudSelectorHandleConverter;
 import org.apache.shenyu.admin.utils.CommonUpstreamUtils;
-import org.apache.shenyu.admin.utils.PathUtils;
+import org.apache.shenyu.common.utils.PathUtils;
 import org.apache.shenyu.common.dto.convert.rule.impl.SpringCloudRuleHandle;
 import org.apache.shenyu.common.dto.convert.selector.DivideUpstream;
 import org.apache.shenyu.common.dto.convert.selector.SpringCloudSelectorHandle;

--- a/shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/init/ContextRegisterListener.java
+++ b/shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/init/ContextRegisterListener.java
@@ -23,6 +23,7 @@ import org.apache.shenyu.client.core.disruptor.ShenyuClientRegisterEventPublishe
 import org.apache.shenyu.client.core.exception.ShenyuClientIllegalArgumentException;
 import org.apache.shenyu.common.enums.RpcTypeEnum;
 import org.apache.shenyu.common.utils.IpUtils;
+import org.apache.shenyu.common.utils.PathUtils;
 import org.apache.shenyu.common.utils.PortUtils;
 import org.apache.shenyu.register.common.config.PropertiesConfig;
 import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
@@ -117,7 +118,7 @@ public class ContextRegisterListener implements ApplicationListener<ContextRefre
         return MetaDataRegisterDTO.builder()
                 .contextPath(contextPath)
                 .appName(appName)
-                .path(contextPath)
+                .path(PathUtils.decoratorPath(contextPath))
                 .rpcType(RpcTypeEnum.SPRING_CLOUD.getName())
                 .enabled(true)
                 .ruleName(contextPath)

--- a/shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/main/java/org/apache/shenyu/client/springmvc/init/ContextRegisterListener.java
+++ b/shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/main/java/org/apache/shenyu/client/springmvc/init/ContextRegisterListener.java
@@ -24,6 +24,7 @@ import org.apache.shenyu.client.core.exception.ShenyuClientIllegalArgumentExcept
 import org.apache.shenyu.common.enums.RpcTypeEnum;
 import org.apache.shenyu.common.exception.ShenyuException;
 import org.apache.shenyu.common.utils.IpUtils;
+import org.apache.shenyu.common.utils.PathUtils;
 import org.apache.shenyu.common.utils.PortUtils;
 import org.apache.shenyu.register.common.config.PropertiesConfig;
 import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
@@ -124,7 +125,7 @@ public class ContextRegisterListener implements ApplicationListener<ContextRefre
         return MetaDataRegisterDTO.builder()
             .contextPath(contextPath)
             .appName(appName)
-            .path(contextPath)
+            .path(PathUtils.decoratorPath(contextPath))
             .rpcType(RpcTypeEnum.HTTP.getName())
             .enabled(true)
             .ruleName(contextPath)

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/utils/PathUtils.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/utils/PathUtils.java
@@ -15,34 +15,33 @@
  * limitations under the License.
  */
 
-package org.apache.shenyu.admin.utils;
+package org.apache.shenyu.common.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.common.constant.AdminConstants;
-import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-public class PathUtilsTest {
-    private static final String URI_WRAPPER = "springCloud/test/**";
-
-    private static final String URI = "springCloud/test";
-
-    @Test
-    public void testDecoratorPath() {
-        String uri = PathUtils.decoratorPath(URI);
-        assertThat(uri, is(URI + AdminConstants.URI_SUFFIX));
-
-        uri = PathUtils.decoratorPath(URI_WRAPPER);
-        assertThat(uri, is(URI + AdminConstants.URI_SUFFIX));
+/**
+ * The type Path utils.
+ */
+public final class PathUtils {
+    
+    /**
+     * Decorator path string.
+     *
+     * @param contextPath the context path
+     * @return the string
+     */
+    public static String decoratorPath(final String contextPath) {
+        return StringUtils.contains(contextPath, AdminConstants.URI_SUFFIX) ? contextPath : contextPath + AdminConstants.URI_SUFFIX;
     }
-
-    @Test
-    public void decoratorContextPath() {
-        String uri = PathUtils.decoratorContextPath(URI);
-        assertThat(uri, is(URI));
-
-        uri = PathUtils.decoratorContextPath(URI_WRAPPER);
-        assertThat(uri, is(URI));
+    
+    /**
+     * Decorator context path string.
+     *
+     * @param contextPath the context path
+     * @return the string
+     */
+    public static String decoratorContextPath(final String contextPath) {
+        return StringUtils.contains(contextPath, AdminConstants.URI_SUFFIX) ? StringUtils.substringBefore(contextPath, AdminConstants.URI_SUFFIX) : contextPath;
     }
 }

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/utils/PathUtilsTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/utils/PathUtilsTest.java
@@ -15,33 +15,34 @@
  * limitations under the License.
  */
 
-package org.apache.shenyu.admin.utils;
+package org.apache.shenyu.common.utils;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.common.constant.AdminConstants;
+import org.junit.jupiter.api.Test;
 
-/**
- * The type Path utils.
- */
-public final class PathUtils {
-    
-    /**
-     * Decorator path string.
-     *
-     * @param contextPath the context path
-     * @return the string
-     */
-    public static String decoratorPath(final String contextPath) {
-        return StringUtils.contains(contextPath, AdminConstants.URI_SUFFIX) ? contextPath : contextPath + AdminConstants.URI_SUFFIX;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PathUtilsTest {
+    private static final String URI_WRAPPER = "springCloud/test/**";
+
+    private static final String URI = "springCloud/test";
+
+    @Test
+    public void testDecoratorPath() {
+        String uri = PathUtils.decoratorPath(URI);
+        assertThat(uri, is(URI + AdminConstants.URI_SUFFIX));
+
+        uri = PathUtils.decoratorPath(URI_WRAPPER);
+        assertThat(uri, is(URI + AdminConstants.URI_SUFFIX));
     }
-    
-    /**
-     * Decorator context path string.
-     *
-     * @param contextPath the context path
-     * @return the string
-     */
-    public static String decoratorContextPath(final String contextPath) {
-        return StringUtils.contains(contextPath, AdminConstants.URI_SUFFIX) ? StringUtils.substringBefore(contextPath, AdminConstants.URI_SUFFIX) : contextPath;
+
+    @Test
+    public void decoratorContextPath() {
+        String uri = PathUtils.decoratorContextPath(URI);
+        assertThat(uri, is(URI));
+
+        uri = PathUtils.decoratorContextPath(URI_WRAPPER);
+        assertThat(uri, is(URI));
     }
 }


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo

For #2969 , mainly done following things.
1. moved `PathUtils` from shenyu-admin to shenyu-common.
2. changed path from `contextPath` to `PathUtils.decoratorPath(contextPath)` to make it using `matches` operator.

After this change, when setting `isFull` to true, the condition in rule will use `matches` operator like below.
```
uri mathces /springcloud/**
// or
uri matches /http/**
```

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
