### PR TITLE
[type:bug]Sync data error when disable metaData.

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/MetaDataMapper.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/MetaDataMapper.java
@@ -25,7 +25,6 @@ import org.apache.shenyu.admin.validation.ExistProvider;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Set;
 
 /**
  * The interface Meta data mapper.
@@ -53,10 +52,10 @@ public interface MetaDataMapper extends ExistProvider {
     /**
      * Select a list of MetaDataDOs by idList.
      *
-     * @param idSet a set of ids
+     * @param idList a list of ids
      * @return a list of MetaDataDOs
      */
-    List<MetaDataDO> selectByIdSet(@Param("idSet") Set<String> idSet);
+    List<MetaDataDO> selectByIdList(@Param("idList") List<String> idList);
     
     /**
      * Find all list.
@@ -132,11 +131,11 @@ public interface MetaDataMapper extends ExistProvider {
     /**
      * update enable batch.
      *
-     * @param idSet   the ids
+     * @param idList  the ids
      * @param enabled the status
      * @return the count
      */
-    int updateEnableBatch(@Param("idSet") Set<String> idSet, @Param("enabled") Boolean enabled);
+    int updateEnableBatch(@Param("idList") List<String> idList, @Param("enabled") Boolean enabled);
     
     /**
      * Delete int.
@@ -147,12 +146,12 @@ public interface MetaDataMapper extends ExistProvider {
     int delete(String id);
     
     /**
-     * batch delete by a set of ids.
+     * batch delete by a list of ids.
      *
-     * @param idSet a set of ids
+     * @param idList a list of ids
      * @return the count of deleted
      */
-    int deleteByIdSet(@Param("idSet") Set<String> idSet);
+    int deleteByIdList(@Param("idList") List<String> idList);
     
     /**
      * the path is existed.

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/MetaDataServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/MetaDataServiceImpl.java
@@ -151,8 +151,10 @@ public class MetaDataServiceImpl implements MetaDataService {
             return AdminConstants.ID_NOT_EXIST;
         }
         List<MetaData> metaDataList = metaDataDoList.stream()
-            .map(metaDataDo -> MetaDataTransfer.INSTANCE.mapToDataEnabled(metaDataDo, enabled))
-            .collect(Collectors.toList());
+            .map(metaDataDo -> {
+                metaDataDo.setEnabled(enabled);
+                return MetaDataTransfer.INSTANCE.mapToData(metaDataDo);
+            }).collect(Collectors.toList());
         metaDataMapper.updateEnableBatch(ids, enabled);
         
         eventPublisher.publishEvent(new DataChangedEvent(ConfigGroupEnum.META_DATA, DataEventTypeEnum.UPDATE,

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/MetaDataTransfer.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/MetaDataTransfer.java
@@ -179,4 +179,27 @@ public enum MetaDataTransfer {
                 .map(v -> v.stream().map(this::mapToVO).collect(Collectors.toList()))
                 .orElse(null);
     }
+
+    /**
+     * Map to data meta data.
+     *
+     * @param metaDataDO the meta data dto
+     * @param enabled    the enabled
+     * @return the meta data
+     */
+    public MetaData mapToDataEnabled(final MetaDataDO metaDataDO, final Boolean enabled) {
+        return Optional.ofNullable(metaDataDO)
+                .map(v -> MetaData.builder()
+                        .id(v.getId())
+                        .appName(v.getAppName())
+                        .path(v.getPath())
+                        .rpcType(v.getRpcType())
+                        .serviceName(v.getServiceName())
+                        .methodName(v.getMethodName())
+                        .parameterTypes(v.getParameterTypes())
+                        .rpcExt(v.getRpcExt())
+                        .enabled(enabled)
+                        .build())
+                .orElse(null);
+    }
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/MetaDataTransfer.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/MetaDataTransfer.java
@@ -179,27 +179,4 @@ public enum MetaDataTransfer {
                 .map(v -> v.stream().map(this::mapToVO).collect(Collectors.toList()))
                 .orElse(null);
     }
-
-    /**
-     * Map to data meta data.
-     *
-     * @param metaDataDO the meta data dto
-     * @param enabled    the enabled
-     * @return the meta data
-     */
-    public MetaData mapToDataEnabled(final MetaDataDO metaDataDO, final Boolean enabled) {
-        return Optional.ofNullable(metaDataDO)
-                .map(v -> MetaData.builder()
-                        .id(v.getId())
-                        .appName(v.getAppName())
-                        .path(v.getPath())
-                        .rpcType(v.getRpcType())
-                        .serviceName(v.getServiceName())
-                        .methodName(v.getMethodName())
-                        .parameterTypes(v.getParameterTypes())
-                        .rpcExt(v.getRpcExt())
-                        .enabled(enabled)
-                        .build())
-                .orElse(null);
-    }
 }

--- a/shenyu-admin/src/main/resources/mappers/meta-data-sqlmap.xml
+++ b/shenyu-admin/src/main/resources/mappers/meta-data-sqlmap.xml
@@ -55,12 +55,12 @@
          WHERE id = #{id,jdbcType=VARCHAR}
     </select>
 
-    <select id="selectByIdSet" resultMap="BaseResultMap">
+    <select id="selectByIdList" resultMap="BaseResultMap">
         SElECT
                 <include refid="Base_Column_List"/>
           FROM meta_data
          WHERE id IN
-                <foreach collection="idSet" item="id" index="index" open="(" separator="," close=")">
+                <foreach collection="idList" item="id" index="index" open="(" separator="," close=")">
                     #{id,jdbcType=VARCHAR}
                 </foreach>
     </select>
@@ -192,7 +192,7 @@
         UPDATE meta_data
            SET enabled = #{enabled,jdbcType=TINYINT}
          WHERE id IN
-                <foreach collection="idSet" index="index" item="id" open="(" separator="," close=")">
+                <foreach collection="idList" index="index" item="id" open="(" separator="," close=")">
                     #{id, jdbcType=VARCHAR}
                 </foreach>
     </update>
@@ -202,10 +202,10 @@
          WHERE id = #{id,jdbcType=VARCHAR}
     </delete>
 
-    <delete id="deleteByIdSet" parameterType="java.lang.String">
+    <delete id="deleteByIdList" parameterType="java.lang.String">
         DELETE FROM meta_data
          WHERE id IN
-                <foreach collection="idSet" item="id" index="index" open="(" separator="," close=")">
+                <foreach collection="idList" item="id" index="index" open="(" separator="," close=")">
                     #{id,jdbcType=VARCHAR}
                 </foreach>
     </delete>

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/MetaDataMapperTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/MetaDataMapperTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Resource;
 import java.sql.Timestamp;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -77,10 +76,10 @@ public final class MetaDataMapperTest extends AbstractSpringIntegrationTest {
         int count2 = metaDataMapper.insert(metaDataDO2);
         assertThat(count2, comparesEqualTo(1));
 
-        Set<String> idSet = Stream.of(metaDataDO.getId(), metaDataDO2.getId()).collect(Collectors.toSet());
-        List<MetaDataDO> resultList = metaDataMapper.selectByIdSet(idSet);
+        List<String> idList = Stream.of(metaDataDO.getId(), metaDataDO2.getId()).collect(Collectors.toList());
+        List<MetaDataDO> resultList = metaDataMapper.selectByIdList(idList);
         assertThat(resultList, hasItems(metaDataDO2, metaDataDO));
-        assertThat(resultList.size(), comparesEqualTo(idSet.size()));
+        assertThat(resultList.size(), comparesEqualTo(idList.size()));
     }
 
     @Test
@@ -204,11 +203,11 @@ public final class MetaDataMapperTest extends AbstractSpringIntegrationTest {
         int count2 = metaDataMapper.insert(metaDataDO2);
         assertThat(count2, comparesEqualTo(1));
 
-        Set<String> idSet = Stream.of(metaDataDO.getId(), metaDataDO2.getId()).collect(Collectors.toSet());
-        int ret = metaDataMapper.updateEnableBatch(idSet, true);
-        assertThat(ret, comparesEqualTo(idSet.size()));
+        List<String> idList = Stream.of(metaDataDO.getId(), metaDataDO2.getId()).collect(Collectors.toList());
+        int ret = metaDataMapper.updateEnableBatch(idList, true);
+        assertThat(ret, comparesEqualTo(idList.size()));
 
-        List<MetaDataDO> resultList = metaDataMapper.selectByIdSet(idSet);
+        List<MetaDataDO> resultList = metaDataMapper.selectByIdList(idList);
         resultList.forEach(result -> assertTrue(result.getEnabled()));
     }
 
@@ -232,9 +231,9 @@ public final class MetaDataMapperTest extends AbstractSpringIntegrationTest {
         int count2 = metaDataMapper.insert(metaDataDO2);
         assertThat(count2, comparesEqualTo(1));
 
-        Set<String> idSet = Stream.of(metaDataDO.getId(), metaDataDO2.getId()).collect(Collectors.toSet());
-        int result = metaDataMapper.deleteByIdSet(idSet);
-        assertThat(result, comparesEqualTo(idSet.size()));
+        List<String> idList = Stream.of(metaDataDO.getId(), metaDataDO2.getId()).collect(Collectors.toList());
+        int result = metaDataMapper.deleteByIdList(idList);
+        assertThat(result, comparesEqualTo(idList.size()));
     }
 
     private MetaDataDO getMetaDataDO() {

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/MetaDataServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/MetaDataServiceTest.java
@@ -47,10 +47,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -134,8 +132,7 @@ public final class MetaDataServiceTest {
     @Test
     public void testEnabled() {
         List<String> ids = Lists.newArrayList("id1", "id2", "id3");
-        Set<String> idSet = new HashSet<>(ids);
-        when(metaDataMapper.selectByIdSet(idSet))
+        when(metaDataMapper.selectByIdList(ids))
                 .thenReturn(Arrays.asList(MetaDataDO.builder().build(), MetaDataDO.builder().build()))
                 .thenReturn(Arrays.asList(MetaDataDO.builder().build(), MetaDataDO.builder().build(), MetaDataDO.builder().build()));
         String msg = metaDataService.enabled(ids, true);
@@ -285,9 +282,8 @@ public final class MetaDataServiceTest {
      */
     private void testDeleteForNotEmptyIds() {
         List<String> ids = Lists.newArrayList("id1", "id1", "id3");
-        Set<String> idSet = new HashSet<>(ids);
-        when(metaDataMapper.selectByIdSet(idSet)).thenReturn(Arrays.asList(MetaDataDO.builder().build(), MetaDataDO.builder().build()));
-        when(metaDataMapper.deleteByIdSet(idSet)).thenReturn(2);
+        when(metaDataMapper.selectByIdList(ids)).thenReturn(Arrays.asList(MetaDataDO.builder().build(), MetaDataDO.builder().build()));
+        when(metaDataMapper.deleteByIdList(ids)).thenReturn(2);
         int count = metaDataService.delete(ids);
         Assertions.assertEquals(2, count,
                 "The count of delete should be 2.");

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/MetaDataServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/MetaDataServiceTest.java
@@ -132,12 +132,11 @@ public final class MetaDataServiceTest {
     @Test
     public void testEnabled() {
         List<String> ids = Lists.newArrayList("id1", "id2", "id3");
+        String msg = metaDataService.enabled(ids, true);
+        assertEquals(AdminConstants.ID_NOT_EXIST, msg);
         when(metaDataMapper.selectByIdList(ids))
                 .thenReturn(Arrays.asList(MetaDataDO.builder().build(), MetaDataDO.builder().build()))
                 .thenReturn(Arrays.asList(MetaDataDO.builder().build(), MetaDataDO.builder().build(), MetaDataDO.builder().build()));
-        String msg = metaDataService.enabled(ids, true);
-        assertEquals(AdminConstants.ID_NOT_EXIST, msg);
-
         msg = metaDataService.enabled(ids, false);
         assertEquals(StringUtils.EMPTY, msg);
     }
@@ -282,9 +281,11 @@ public final class MetaDataServiceTest {
      */
     private void testDeleteForNotEmptyIds() {
         List<String> ids = Lists.newArrayList("id1", "id1", "id3");
+        int count = metaDataService.delete(ids);
+        Assertions.assertEquals(0, count, "The count of delete should be 0.");
         when(metaDataMapper.selectByIdList(ids)).thenReturn(Arrays.asList(MetaDataDO.builder().build(), MetaDataDO.builder().build()));
         when(metaDataMapper.deleteByIdList(ids)).thenReturn(2);
-        int count = metaDataService.delete(ids);
+        count = metaDataService.delete(ids);
         Assertions.assertEquals(2, count,
                 "The count of delete should be 2.");
     }


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->

Fix bug, when disable metaData.
```java
public String enabled(final List<String> ids, final Boolean enabled) {
        
        Set<String> idSet = Optional.ofNullable(ids).orElseGet(ArrayList::new)
                .stream().filter(StringUtils::isNotEmpty).collect(Collectors.toSet());
        if (CollectionUtils.isEmpty(idSet)) {
            return AdminConstants.ID_NOT_EXIST;
        }
        List<MetaDataDO> metaDataDoList = Optional.ofNullable(metaDataMapper.selectByIdSet(idSet)).orElseGet(ArrayList::new);
        if (idSet.size() != metaDataDoList.size()) {
            return AdminConstants.ID_NOT_EXIST;
        }
        List<MetaData> metaDataList = metaDataDoList.stream()
                .map(MetaDataTransfer.INSTANCE::mapToData)
                .collect(Collectors.toList());
        metaDataMapper.updateEnableBatch(idSet, enabled);
        
        // the element in metaDataList still be enabled when disable metaData
        eventPublisher.publishEvent(new DataChangedEvent(ConfigGroupEnum.META_DATA, DataEventTypeEnum.UPDATE,
                metaDataList));
        
        return StringUtils.EMPTY;
    }
```

Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
