### PR TITLE
[tpye:refactor #2985]Fix Hystrix-plugin tests failure

### DIFF
--- a/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/HystrixPluginTest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/HystrixPluginTest.java
@@ -82,10 +82,14 @@ public final class HystrixPluginTest extends AbstractPluginDataInit {
         }.getType();
         Future<Map<String, Object>> resp0 = this.getService().submit(() -> HttpHelper.INSTANCE.getFromGateway(TEST_HYSTRIX_BAD_REQUEST_PATH, returnType));
         Future<Map<String, Object>> resp1 = this.getService().submit(() -> HttpHelper.INSTANCE.getFromGateway(TEST_HYSTRIX_BAD_REQUEST_PATH, returnType));
+        Future<Map<String, Object>> resp2 = this.getService().submit(() -> HttpHelper.INSTANCE.getFromGateway(TEST_HYSTRIX_BAD_REQUEST_PATH, returnType));
         Stream.of(resp0.get()).filter(s -> null != s.get("message")).forEach(imp -> {
             resultSet.add(imp.get("message").toString());
         });
         Stream.of(resp1.get()).filter(s -> null != s.get("message")).forEach(imp -> {
+            resultSet.add(imp.get("message").toString());
+        });
+        Stream.of(resp2.get()).filter(s -> null != s.get("message")).forEach(imp -> {
             resultSet.add(imp.get("message").toString());
         });
         assertTrue(resultSet.contains("HystrixPlugin fallback success, please check your service status!"));


### PR DESCRIPTION
related pr: #2985 

With Jooks-me's reminder, I noticed an occasional bug in the integration tests of the hystrix plugin.

From my research, I think this is a bug inside hystrix. The overall logic of the test case is correct. The semaphore in the test case is limited to 1. When there is a new request for access, it will be directly blown and the corresponding prompt information will be returned. Other friends are also welcome to help review this issue.

I submitted a patch pr, perhaps this will reduce the probability of testing errors. If anyone's CI is having issues with the hystrix plugin test bug, please @erdengk on GitHub.

thank you very much