### PR TITLE
encode queryParam's key to avoid 400 error when queryParam is like ?p…

### DIFF
--- a/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/utils/RequestQueryCodecUtil.java
+++ b/shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/utils/RequestQueryCodecUtil.java
@@ -48,8 +48,10 @@ public final class RequestQueryCodecUtil {
         return queryParams.keySet().stream()
                 .map(key -> queryParams.get(key).stream()
                         .map(item -> Optional.ofNullable(item)
-                                .map(value -> String.join("=", key, UriUtils.encode(value, StandardCharsets.UTF_8)))
-                                .orElse(key))
+                                .map(value -> String.join("=",
+                                        UriUtils.encode(key, StandardCharsets.UTF_8),
+                                        UriUtils.encode(value, StandardCharsets.UTF_8)))
+                                .orElse(UriUtils.encode(key, StandardCharsets.UTF_8)))
                         .filter(StringUtils::isNoneBlank)
                         .collect(Collectors.joining("&")))
                 .collect(Collectors.joining("&")).trim();


### PR DESCRIPTION
encode queryParam's key to avoid 400 error when queryParam is like ?params[name]=123&params[sex]=male

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [*] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [*] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
