### PR TITLE
[ISSUE #3318] Fix keep waiting for acquiring memory unexpectedly 

### DIFF
--- a/shenyu-common/src/main/java/org/apache/shenyu/common/concurrent/MemoryLimiter.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/concurrent/MemoryLimiter.java
@@ -214,13 +214,12 @@ public class MemoryLimiter {
         }
         acquireLock.lockInterruptibly();
         try {
-            final long sum = memory.sum();
             final long objectSize = inst.getObjectSize(o);
-            while (sum + objectSize >= memoryLimit) {
+            while (memory.sum() + objectSize >= memoryLimit) {
                 notLimited.await();
             }
             memory.add(objectSize);
-            if (sum < memoryLimit) {
+            if (memory.sum() < memoryLimit) {
                 notLimited.signal();
             }
         } finally {

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/concurrent/MemoryLimiterTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/concurrent/MemoryLimiterTest.java
@@ -22,12 +22,19 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.lang.instrument.Instrumentation;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 /**
- * Test cases for MemoryLimiter
+ * Test cases for MemoryLimiter.
  */
 public final class MemoryLimiterTest {
 
@@ -47,15 +54,15 @@ public final class MemoryLimiterTest {
 
     @Test
     public void testCreateMemoryLimiterWhenIllegal() {
-        long less_than_zero = -1;
-        assertThrows(IllegalArgumentException.class, () -> new MemoryLimiter(less_than_zero, instrumentation));
+        long lessThanZero = -1;
+        assertThrows(IllegalArgumentException.class, () -> new MemoryLimiter(lessThanZero, instrumentation));
     }
 
     @Test
     public void testSetMemoryLimiterWhenIllegal() {
-        long less_than_zero = -1;
+        long lessThanZero = -1;
         MemoryLimiter memoryLimiter = new MemoryLimiter(instrumentation);
-        assertThrows(IllegalArgumentException.class, () -> memoryLimiter.setMemoryLimit(less_than_zero));
+        assertThrows(IllegalArgumentException.class, () -> memoryLimiter.setMemoryLimit(lessThanZero));
     }
 
     @Test
@@ -116,7 +123,7 @@ public final class MemoryLimiterTest {
     }
 
     @Test
-    public void testAcquireWaitForNotify() throws Exception{
+    public void testAcquireWaitForNotify() throws Exception {
         MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize + 1, instrumentation);
         memoryLimiter.acquire(testObject);
         ExecutorService executorService = Executors.newFixedThreadPool(1);
@@ -136,7 +143,7 @@ public final class MemoryLimiterTest {
     }
 
     @Test
-    public void testReleaseWhenNullObject() throws InterruptedException{
+    public void testReleaseWhenNullObject() throws InterruptedException {
         MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize + 1, instrumentation);
         memoryLimiter.acquire(testObject);
 

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/concurrent/MemoryLimiterTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/concurrent/MemoryLimiterTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.common.concurrent;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.instrument.Instrumentation;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test cases for MemoryLimiter
+ */
+public final class MemoryLimiterTest {
+
+    private static Instrumentation instrumentation;
+
+    private static Object testObject;
+
+    private static long testObjectSize;
+
+    @BeforeAll
+    public static void initializeInstrumentation() {
+        ByteBuddyAgent.install();
+        instrumentation = ByteBuddyAgent.getInstrumentation();
+        testObject = Integer.MAX_VALUE;
+        testObjectSize = instrumentation.getObjectSize(testObject);
+    }
+
+    @Test
+    public void testCreateMemoryLimiterWhenIllegal() {
+        long less_than_zero = -1;
+        assertThrows(IllegalArgumentException.class, () -> new MemoryLimiter(less_than_zero, instrumentation));
+    }
+
+    @Test
+    public void testSetMemoryLimiterWhenIllegal() {
+        long less_than_zero = -1;
+        MemoryLimiter memoryLimiter = new MemoryLimiter(instrumentation);
+        assertThrows(IllegalArgumentException.class, () -> memoryLimiter.setMemoryLimit(less_than_zero));
+    }
+
+    @Test
+    public void testAcquireWhenNullObject() {
+        MemoryLimiter memoryLimiter = new MemoryLimiter(instrumentation);
+        assertThrows(NullPointerException.class, () -> memoryLimiter.acquire(null));
+        assertThrows(NullPointerException.class, () -> memoryLimiter.acquire(null, 10, TimeUnit.SECONDS));
+        assertThrows(NullPointerException.class, () -> memoryLimiter.acquireInterruptibly(null));
+    }
+
+    @Test
+    public void testAcquireWhenEqualToLimit() {
+        MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize, instrumentation);
+        assertFalse(memoryLimiter.acquire(testObject));
+    }
+
+    @Test
+    public void testAcquireWhenExceedLimit() {
+        MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize + 1, instrumentation);
+        assertTrue(memoryLimiter.acquire(testObject));
+        memoryLimiter.setMemoryLimit(testObjectSize - 1);
+        assertFalse(memoryLimiter.acquire(testObject));
+        memoryLimiter.setMemoryLimit(testObjectSize + 1);
+        assertFalse(memoryLimiter.acquire(testObject));
+    }
+
+    @Test
+    public void testAcquireConcurrent() throws Exception {
+        MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize * 2 + 1, instrumentation);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        // two thread acquire concurrently.
+        for (int i = 0; i < 2; i++) {
+            Future<Boolean> acquireResult = executorService.submit(() -> memoryLimiter.acquire(testObject));
+            assertTrue(acquireResult.get());
+        }
+        assertEquals(testObjectSize * 2, memoryLimiter.getCurrentMemory());
+        executorService.shutdown();
+    }
+
+    @Test
+    public void testAcquireWithTimeWaitNotRelease() throws InterruptedException {
+        MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize + 1, instrumentation);
+        memoryLimiter.acquire(testObject);
+        assertFalse(memoryLimiter.acquire(testObject, 1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testAcquireWithTimeWaitAfterRelease() throws Exception {
+        MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize + 1, instrumentation);
+        memoryLimiter.acquire(testObject);
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        Future<Boolean> acquireResult = executorService.submit(() -> memoryLimiter.acquire(testObject, 4, TimeUnit.SECONDS));
+        Thread.sleep(2000);
+        memoryLimiter.release(testObject);
+        assertTrue(acquireResult.get());
+        assertEquals(testObjectSize, memoryLimiter.getCurrentMemory());
+        executorService.shutdown();
+    }
+
+    @Test
+    public void testAcquireWaitForNotify() throws Exception{
+        MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize + 1, instrumentation);
+        memoryLimiter.acquire(testObject);
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        Future<Boolean> acquireResult = executorService.submit(() -> {
+            try {
+                memoryLimiter.acquireInterruptibly(testObject);
+                return Boolean.TRUE;
+            } catch (InterruptedException e) {
+                return Boolean.FALSE;
+            }
+        });
+        Thread.sleep(3000);
+        memoryLimiter.release(testObject);
+        assertTrue(acquireResult.get());
+        assertEquals(testObjectSize, memoryLimiter.getCurrentMemory());
+        executorService.shutdown();
+    }
+
+    @Test
+    public void testReleaseWhenNullObject() throws InterruptedException{
+        MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize + 1, instrumentation);
+        memoryLimiter.acquire(testObject);
+
+        memoryLimiter.release(null);
+        assertEquals(testObjectSize, memoryLimiter.getCurrentMemory());
+
+        memoryLimiter.releaseInterruptibly(null);
+        assertEquals(testObjectSize, memoryLimiter.getCurrentMemory());
+
+        memoryLimiter.releaseInterruptibly(null, 1, TimeUnit.SECONDS);
+        assertEquals(testObjectSize, memoryLimiter.getCurrentMemory());
+    }
+
+    @Test
+    public void testReleaseInterruptiblyWaitForNotify() throws Exception {
+        MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize + 1, instrumentation);
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        Future<Boolean> acquireResult = executorService.submit(() -> {
+            try {
+                memoryLimiter.releaseInterruptibly(testObject);
+                return Boolean.TRUE;
+            } catch (InterruptedException e) {
+                return Boolean.FALSE;
+            }
+        });
+        Thread.sleep(3000);
+        memoryLimiter.acquire(testObject);
+        assertTrue(acquireResult.get());
+        assertEquals(0, memoryLimiter.getCurrentMemory());
+        executorService.shutdown();
+    }
+
+    @Test
+    public void testReleaseInterruptiblyWithTimeWait() throws Exception {
+        MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize + 1, instrumentation);
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        Future<Boolean> acquireResult = executorService.submit(() -> {
+            try {
+                memoryLimiter.releaseInterruptibly(testObject, 4, TimeUnit.SECONDS);
+                return Boolean.TRUE;
+            } catch (InterruptedException e) {
+                return Boolean.FALSE;
+            }
+        });
+        Thread.sleep(2000);
+        memoryLimiter.acquire(testObject);
+        assertTrue(acquireResult.get());
+        assertEquals(0, memoryLimiter.getCurrentMemory());
+        executorService.shutdown();
+    }
+
+    @Test
+    public void testRemainMemory() {
+        MemoryLimiter memoryLimiter = new MemoryLimiter(testObjectSize + 1, instrumentation);
+        memoryLimiter.acquire(testObject);
+        assertEquals(1, memoryLimiter.getCurrentRemainMemory());
+    }
+}


### PR DESCRIPTION
Issue #3318 , fix `MemoryLimiter.acquireInterruptibly` keep waiting unexpectedly error. Add an unit test class `MemoryLimiterTest`
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
