### PR TITLE
[fix:compatibility #3374]grpc plugin compatible with low version and output standard format json

### DIFF
--- a/shenyu-client/shenyu-client-grpc/src/main/java/org/apache/shenyu/client/grpc/json/JsonServerServiceInterceptor.java
+++ b/shenyu-client/shenyu-client-grpc/src/main/java/org/apache/shenyu/client/grpc/json/JsonServerServiceInterceptor.java
@@ -17,24 +17,27 @@
 
 package org.apache.shenyu.client.grpc.json;
 
-import com.google.common.collect.Maps;
-import io.grpc.MethodDescriptor;
-import io.grpc.ServerMethodDefinition;
-import io.grpc.ServerServiceDefinition;
-import io.grpc.ServiceDescriptor;
-import io.grpc.ServerCallHandler;
-import io.grpc.ServerCall;
-import io.grpc.Metadata;
-import org.apache.shenyu.common.exception.ShenyuException;
-import org.apache.shenyu.common.utils.ReflectUtils;
-import org.apache.shenyu.protocol.grpc.constant.GrpcConstants;
-import org.apache.shenyu.protocol.grpc.message.JsonMessage;
-
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import org.apache.shenyu.common.exception.ShenyuException;
+import org.apache.shenyu.common.utils.ReflectUtils;
+import org.apache.shenyu.protocol.grpc.constant.GrpcConstants;
+import org.apache.shenyu.protocol.grpc.message.JsonMessage;
+
+import com.google.common.collect.Maps;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.PrototypeMarshaller;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.ServiceDescriptor;
 
 /**
  * Support json invoke.
@@ -77,11 +80,20 @@ public class JsonServerServiceInterceptor {
         for (final ServerMethodDefinition<?, ?> definition : serviceDef.getMethods()) {
             MethodDescriptor.Marshaller<?> requestMarshaller = definition.getMethodDescriptor().getRequestMarshaller();
             Field defaultInstanceField = ReflectUtils.getField(requestMarshaller.getClass(), "defaultInstance");
+            Class grpcRequestParamClass = null;
             if (Objects.isNull(defaultInstanceField)) {
-                throw new ShenyuException(String.format("can not get defaultInstance Field of %s", requestMarshaller.getClass()));
+                // Compatible with lower versions. eg: grpc 1.6.0
+                if (requestMarshaller instanceof MethodDescriptor.PrototypeMarshaller) {
+                    MethodDescriptor.PrototypeMarshaller<?> prototypeMarshaller = (PrototypeMarshaller<?>) requestMarshaller;
+                    if (Objects.isNull(prototypeMarshaller.getMessagePrototype())) {
+                        throw new ShenyuException(String.format("can not get defaultInstance Field of %s", requestMarshaller.getClass()));
+                    }
+                    grpcRequestParamClass = prototypeMarshaller.getMessagePrototype().getClass();
+                }
+            } else {
+                defaultInstanceField.setAccessible(true);
+                grpcRequestParamClass = defaultInstanceField.get(requestMarshaller).getClass();
             }
-
-            defaultInstanceField.setAccessible(true);
 
             String fullMethodName = definition.getMethodDescriptor().getFullMethodName();
             MethodDescriptor.MethodType methodType = definition.getMethodDescriptor().getType();
@@ -89,7 +101,7 @@ public class JsonServerServiceInterceptor {
 
             String[] splitMethodName = fullMethodName.split("/");
             fullMethodName = splitMethodName[0] + GrpcConstants.GRPC_JSON_SERVICE + "/" + splitMethodName[1];
-            REQUEST_CLAZZ_MAP.put(fullMethodName, defaultInstanceField.get(requestMarshaller).getClass());
+            REQUEST_CLAZZ_MAP.put(fullMethodName, grpcRequestParamClass);
 
             final MethodDescriptor<?, ?> originalMethodDescriptor = definition.getMethodDescriptor();
             final MethodDescriptor<T, T> wrappedMethodDescriptor = originalMethodDescriptor
@@ -111,15 +123,14 @@ public class JsonServerServiceInterceptor {
             fullMethodName = splitMethodName[0] + GrpcConstants.GRPC_JSON_SERVICE + "/" + splitMethodName[1];
             fullMethodNameField.set(md, fullMethodName);
 
+            // Compatible with lower versions. Lower versions do not have this field. eg: grpc 1.6.0
             Field serviceNameField = ReflectUtils.getField(md.getClass(), "serviceName");
-            if (Objects.isNull(serviceNameField)) {
-                throw new ShenyuException(String.format("can not get serviceName Field Field of %s", md.getClass()));
+            if (Objects.nonNull(serviceNameField)) {
+                serviceNameField.setAccessible(true);
+                String serviceName = (String) serviceNameField.get(md);
+                serviceName = serviceName + GrpcConstants.GRPC_JSON_SERVICE;
+                serviceNameField.set(md, serviceName);
             }
-            serviceNameField.setAccessible(true);
-            String serviceName = (String) serviceNameField.get(md);
-            serviceName = serviceName + GrpcConstants.GRPC_JSON_SERVICE;
-            serviceNameField.set(md, serviceName);
-
             build.addMethod(md);
         }
         final ServerServiceDefinition.Builder serviceBuilder = ServerServiceDefinition

--- a/shenyu-integrated-test/shenyu-integrated-test-grpc/src/test/java/org/apache/shenyu/integrated/test/grpc/GrpcPluginTest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-grpc/src/test/java/org/apache/shenyu/integrated/test/grpc/GrpcPluginTest.java
@@ -45,7 +45,7 @@ public class GrpcPluginTest extends AbstractPluginDataInit {
     public void testHelloWorld() throws Exception {
         JsonObject request = buildGrpcRequest();
         JsonArray response = HttpHelper.INSTANCE.postGateway("/grpc/echo", request, JsonArray.class);
-        Map<String, Object> result = GsonUtils.getInstance().toObjectMap(response.get(0).getAsString(), Object.class);
+        Map<String, Object> result = GsonUtils.getInstance().toObjectMap(response.get(0).toString(), Object.class);
         assertEquals("ReceivedHELLO", result.get("message"));
     }
 

--- a/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/MessageWriter.java
+++ b/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/MessageWriter.java
@@ -20,11 +20,11 @@ package org.apache.shenyu.plugin.grpc.proto;
 import java.util.HashMap;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.shenyu.common.utils.GsonUtils;
 import org.apache.shenyu.protocol.grpc.message.JsonMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
@@ -37,6 +37,8 @@ import io.grpc.stub.StreamObserver;
 public final class MessageWriter<T extends Message> implements StreamObserver<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(MessageWriter.class);
+
+    private static final Gson GSON = new Gson();
 
     private final ShenyuGrpcResponse grpcResponse;
 
@@ -62,7 +64,7 @@ public final class MessageWriter<T extends Message> implements StreamObserver<T>
             respData = respData.trim();
             if (StringUtils.startsWith(respData, "{") && StringUtils.endsWith(respData, "}")) {
                 // standardized json output.
-                grpcResponse.getResults().add(GsonUtils.getGson().fromJson(respData,
+                grpcResponse.getResults().add(GSON.fromJson(respData,
                         new TypeToken<HashMap<String, Object>>() {
                         }.getType()));
             }

--- a/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/MessageWriter.java
+++ b/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/MessageWriter.java
@@ -19,6 +19,7 @@ package org.apache.shenyu.plugin.grpc.proto;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.shenyu.common.utils.JsonUtils;
 import org.apache.shenyu.protocol.grpc.message.JsonMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,7 @@ public final class MessageWriter<T extends Message> implements StreamObserver<T>
             respData = respData.trim();
             if (StringUtils.startsWith(respData, "{") && StringUtils.endsWith(respData, "}")) {
                 // standardized json output
-                grpcResponse.getResults().add(GsonUtils.getInstance().toObjectMap(respData));
+                grpcResponse.getResults().add(JsonUtils.toMap(respData));
             }
         } else {
             grpcResponse.getResults().add(respData);

--- a/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/MessageWriter.java
+++ b/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/MessageWriter.java
@@ -17,13 +17,15 @@
 
 package org.apache.shenyu.plugin.grpc.proto;
 
+import java.util.HashMap;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.common.utils.GsonUtils;
-import org.apache.shenyu.common.utils.JsonUtils;
 import org.apache.shenyu.protocol.grpc.message.JsonMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.reflect.TypeToken;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
 
@@ -45,8 +47,8 @@ public final class MessageWriter<T extends Message> implements StreamObserver<T>
     /**
      * New instance.
      *
-     * @param results  results
-     * @param <T>      t
+     * @param results results
+     * @param <T> t
      * @return message message
      */
     public static <T extends Message> MessageWriter<T> newInstance(final ShenyuGrpcResponse results) {
@@ -60,7 +62,9 @@ public final class MessageWriter<T extends Message> implements StreamObserver<T>
             respData = respData.trim();
             if (StringUtils.startsWith(respData, "{") && StringUtils.endsWith(respData, "}")) {
                 // standardized json output
-                grpcResponse.getResults().add(JsonUtils.toMap(respData));
+                grpcResponse.getResults().add(GsonUtils.getGson().fromJson(respData,
+                        new TypeToken<HashMap<String, Object>>() {
+                        }.getType()));
             }
         } else {
             grpcResponse.getResults().add(respData);

--- a/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/MessageWriter.java
+++ b/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/MessageWriter.java
@@ -17,12 +17,16 @@
 
 package org.apache.shenyu.plugin.grpc.proto;
 
-import com.google.protobuf.DynamicMessage;
-import com.google.protobuf.Message;
-import io.grpc.stub.StreamObserver;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.shenyu.common.utils.GsonUtils;
 import org.apache.shenyu.protocol.grpc.message.JsonMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
+
+import io.grpc.stub.StreamObserver;
 
 /**
  * MessageWriter.
@@ -51,7 +55,15 @@ public final class MessageWriter<T extends Message> implements StreamObserver<T>
     @Override
     public void onNext(final T value) {
         String respData = JsonMessage.getDataFromDynamicMessage((DynamicMessage) value);
-        grpcResponse.getResults().add(respData);
+        if (StringUtils.isNotBlank(respData)) {
+            respData = respData.trim();
+            if (StringUtils.startsWith(respData, "{") && StringUtils.endsWith(respData, "}")) {
+                // standardized json output
+                grpcResponse.getResults().add(GsonUtils.getInstance().toObjectMap(respData));
+            }
+        } else {
+            grpcResponse.getResults().add(respData);
+        }
     }
 
     @Override

--- a/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/MessageWriter.java
+++ b/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/MessageWriter.java
@@ -61,7 +61,7 @@ public final class MessageWriter<T extends Message> implements StreamObserver<T>
         if (StringUtils.isNotBlank(respData)) {
             respData = respData.trim();
             if (StringUtils.startsWith(respData, "{") && StringUtils.endsWith(respData, "}")) {
-                // standardized json output
+                // standardized json output.
                 grpcResponse.getResults().add(GsonUtils.getGson().fromJson(respData,
                         new TypeToken<HashMap<String, Object>>() {
                         }.getType()));

--- a/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/ShenyuGrpcResponse.java
+++ b/shenyu-plugin/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/proto/ShenyuGrpcResponse.java
@@ -29,7 +29,7 @@ public class ShenyuGrpcResponse implements Serializable {
 
     private static final long serialVersionUID = 4182753303732523014L;
 
-    private List<String> results;
+    private List<Object> results;
 
     /**
      * Instantiates a new Shenyu grpc response.
@@ -43,7 +43,7 @@ public class ShenyuGrpcResponse implements Serializable {
      *
      * @return the results
      */
-    public List<String> getResults() {
+    public List<Object> getResults() {
         return results;
     }
 
@@ -52,7 +52,7 @@ public class ShenyuGrpcResponse implements Serializable {
      *
      * @param results the results
      */
-    public void setResults(final List<String> results) {
+    public void setResults(final List<Object> results) {
         this.results = results;
     }
 }


### PR DESCRIPTION
 Fixes #3374 
Compatible with low version and output standard format json

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.

## output standard format json
### before
![图片](https://user-images.githubusercontent.com/12478263/166848709-18136e59-08e5-4877-8c34-4769d201832e.png)
### after
![图片](https://user-images.githubusercontent.com/12478263/166848751-08d82553-242e-468d-81d7-2ccb44f2ea5b.png)

## defaultInstance field compatible
### before, grpc low version have no `defaultInstance` field.
<img width="1408" alt="图片" src="https://user-images.githubusercontent.com/12478263/166848973-7432ea23-2fae-4ed5-8336-4f2697bb61ec.png">
### after

```java 
                if (requestMarshaller instanceof MethodDescriptor.PrototypeMarshaller) {
                    MethodDescriptor.PrototypeMarshaller<?> prototypeMarshaller = (PrototypeMarshaller<?>) requestMarshaller;
                    if (Objects.isNull(prototypeMarshaller.getMessagePrototype())) {
                        throw new ShenyuException(String.format("can not get defaultInstance Field of %s", requestMarshaller.getClass()));
                    }
                    grpcRequestParamClass = prototypeMarshaller.getMessagePrototype().getClass();
                }
```
## serviceName field compatible
### before
Lower versions do not have this field `serviceName` to throw exceptions
### after
No exception is thrown if the field is empty, and the service name is set if the field is not empty.
