### PR TITLE
[ISSUR #3362] Replace zookeeper client to Curator and save data in zk without magic header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <curator-test.version>4.0.1</curator-test.version>
         <curator.version>5.2.1</curator.version>
         <wiremock.version>2.18.0</wiremock.version>
-        <zookeeper.version>3.5.6</zookeeper.version>
+        <zookeeper.version>3.6.3</zookeeper.version>
         <zkclient.version>0.10</zkclient.version>
         <shiro.version>1.8.0</shiro.version>
         <jwt.version>3.12.0</jwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
@@ -357,6 +358,12 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>log4j</artifactId>
+                        <groupId>log4j</groupId>
+                    </exclusion>
+                </exclusions>
                 <version>${zookeeper.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <skipTests>false</skipTests>
         <undertow.version>2.2.2.Final</undertow.version>
         <curator-test.version>4.0.1</curator-test.version>
+        <curator.version>5.2.1</curator.version>
         <wiremock.version>2.18.0</wiremock.version>
         <zookeeper.version>3.5.6</zookeeper.version>
         <zkclient.version>0.10</zkclient.version>
@@ -410,6 +411,27 @@
                 <groupId>com.sun.mail</groupId>
                 <artifactId>javax.mail</artifactId>
                 <version>${mail.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-framework</artifactId>
+                <version>${curator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-recipes</artifactId>
+                <version>${curator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-x-async</artifactId>
+                <version>${curator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-test</artifactId>
+                <version>${curator.version}</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,6 @@
         <tars.version>1.7.2</tars.version>
         <skipTests>false</skipTests>
         <undertow.version>2.2.2.Final</undertow.version>
-        <curator-test.version>4.0.1</curator-test.version>
         <curator.version>5.2.1</curator.version>
         <wiremock.version>2.18.0</wiremock.version>
         <zookeeper.version>3.6.3</zookeeper.version>

--- a/shenyu-admin/pom.xml
+++ b/shenyu-admin/pom.xml
@@ -179,21 +179,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo-shaded</artifactId>
         </dependency>

--- a/shenyu-admin/pom.xml
+++ b/shenyu-admin/pom.xml
@@ -179,6 +179,21 @@
         </dependency>
 
         <dependency>
+            <groupId>com.101tec</groupId>
+            <artifactId>zkclient</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo-shaded</artifactId>
         </dependency>

--- a/shenyu-admin/pom.xml
+++ b/shenyu-admin/pom.xml
@@ -246,6 +246,11 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <profiles>

--- a/shenyu-admin/pom.xml
+++ b/shenyu-admin/pom.xml
@@ -229,12 +229,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-test</artifactId>
-            <version>${curator-test.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
             <version>${aspectjweaver.version}</version>

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/DataSyncConfiguration.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/DataSyncConfiguration.java
@@ -20,7 +20,6 @@ package org.apache.shenyu.admin.config;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.ecwid.consul.v1.ConsulClient;
 import io.etcd.jetcd.Client;
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.shenyu.admin.config.properties.ConsulProperties;
 import org.apache.shenyu.admin.config.properties.EtcdProperties;
 import org.apache.shenyu.admin.config.properties.HttpSyncProperties;
@@ -39,6 +38,7 @@ import org.apache.shenyu.admin.listener.websocket.WebsocketCollector;
 import org.apache.shenyu.admin.listener.websocket.WebsocketDataChangedListener;
 import org.apache.shenyu.admin.listener.zookeeper.ZookeeperDataChangedInit;
 import org.apache.shenyu.admin.listener.zookeeper.ZookeeperDataChangedListener;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -84,7 +84,7 @@ public class DataSyncConfiguration {
          */
         @Bean
         @ConditionalOnMissingBean(ZookeeperDataChangedListener.class)
-        public DataChangedListener zookeeperDataChangedListener(final ZkClient zkClient) {
+        public DataChangedListener zookeeperDataChangedListener(final ZookeeperClient zkClient) {
             return new ZookeeperDataChangedListener(zkClient);
         }
 
@@ -96,7 +96,7 @@ public class DataSyncConfiguration {
          */
         @Bean
         @ConditionalOnMissingBean(ZookeeperDataChangedInit.class)
-        public DataChangedInit zookeeperDataChangedInit(final ZkClient zkClient) {
+        public DataChangedInit zookeeperDataChangedInit(final ZookeeperClient zkClient) {
             return new ZookeeperDataChangedInit(zkClient);
         }
     }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/ZookeeperConfiguration.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/ZookeeperConfiguration.java
@@ -17,11 +17,14 @@
 
 package org.apache.shenyu.admin.config;
 
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.shenyu.admin.config.properties.ZookeeperProperties;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperConfig;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+
+import java.util.Objects;
 
 /**
  * ZookeeperConfiguration.
@@ -30,14 +33,21 @@ import org.springframework.context.annotation.Bean;
 public class ZookeeperConfiguration {
 
     /**
-     * register zkClient in spring ioc.
+     * register ZookeeperClient in spring ioc.
      *
      * @param zookeeperProp the zookeeper configuration
-     * @return ZkClient {@linkplain ZkClient}
+     * @return ZookeeperClient {@linkplain ZookeeperClient}
      */
     @Bean
-    @ConditionalOnMissingBean(ZkClient.class)
-    public ZkClient zkClient(final ZookeeperProperties zookeeperProp) {
-        return new ZkClient(zookeeperProp.getUrl(), zookeeperProp.getSessionTimeout(), zookeeperProp.getConnectionTimeout());
+    @ConditionalOnMissingBean(ZookeeperClient.class)
+    public ZookeeperClient zookeeperClient(final ZookeeperProperties zookeeperProp) {
+        int sessionTimeout = Objects.isNull(zookeeperProp.getSessionTimeout()) ? 3000 : zookeeperProp.getSessionTimeout();
+        int connectionTimeout = Objects.isNull(zookeeperProp.getConnectionTimeout()) ? 3000 : zookeeperProp.getConnectionTimeout();
+        ZookeeperConfig zkConfig = new ZookeeperConfig(zookeeperProp.getUrl());
+        zkConfig.setSessionTimeoutMilliseconds(sessionTimeout)
+                .setConnectionTimeoutMilliseconds(connectionTimeout);
+        ZookeeperClient client = new ZookeeperClient(zkConfig);
+        client.start();
+        return client;
     }
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/ZookeeperProperties.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/ZookeeperProperties.java
@@ -31,8 +31,6 @@ public class ZookeeperProperties {
 
     private Integer connectionTimeout;
 
-    private String serializer;
-
     /**
      * Gets the value of url.
      *
@@ -85,23 +83,5 @@ public class ZookeeperProperties {
      */
     public void setConnectionTimeout(final Integer connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
-    }
-
-    /**
-     * Gets the value of serializer.
-     *
-     * @return the value of serializer
-     */
-    public String getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the serializer.
-     *
-     * @param serializer serializer
-     */
-    public void setSerializer(final String serializer) {
-        this.serializer = serializer;
     }
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedInit.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedInit.java
@@ -17,30 +17,30 @@
 
 package org.apache.shenyu.admin.listener.zookeeper;
 
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.shenyu.admin.listener.AbstractDataChangedInit;
 import org.apache.shenyu.common.constant.DefaultPathConstants;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
 
 /**
  * The type Zookeeper data changed init.
  */
 public class ZookeeperDataChangedInit extends AbstractDataChangedInit {
 
-    private final ZkClient zkClient;
+    private final ZookeeperClient zkClient;
 
     /**
      * Instantiates a new Zookeeper data changed init.
      *
      * @param zkClient        the zk client
      */
-    public ZookeeperDataChangedInit(final ZkClient zkClient) {
+    public ZookeeperDataChangedInit(final ZookeeperClient zkClient) {
         this.zkClient = zkClient;
     }
 
     @Override
     protected boolean notExist() {
-        return !zkClient.exists(DefaultPathConstants.PLUGIN_PARENT)
-                && !zkClient.exists(DefaultPathConstants.APP_AUTH_PARENT)
-                && !zkClient.exists(DefaultPathConstants.META_DATA);
+        return !zkClient.isExist(DefaultPathConstants.PLUGIN_PARENT)
+                && !zkClient.isExist(DefaultPathConstants.APP_AUTH_PARENT)
+                && !zkClient.isExist(DefaultPathConstants.META_DATA);
     }
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedListener.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedListener.java
@@ -97,6 +97,7 @@ public class ZookeeperDataChangedListener implements DataChangedListener {
             }
             //create or update
             insertZkNode(pluginPath, data);
+            LOG.debug("created path: {} with data: {}", pluginPath, data);
         }
     }
 
@@ -112,10 +113,9 @@ public class ZookeeperDataChangedListener implements DataChangedListener {
                 deleteZkPath(selectorRealPath);
                 continue;
             }
-            String selectorParentPath = DefaultPathConstants.buildSelectorParentPath(data.getPluginName());
-            createZkNode(selectorParentPath);
             //create or update
             insertZkNode(selectorRealPath, data);
+            LOG.debug("created path: {} with data: {}", selectorRealPath, data);
         }
     }
 
@@ -131,20 +131,17 @@ public class ZookeeperDataChangedListener implements DataChangedListener {
                 deleteZkPath(ruleRealPath);
                 continue;
             }
-            String ruleParentPath = DefaultPathConstants.buildRuleParentPath(data.getPluginName());
-            createZkNode(ruleParentPath);
             //create or update
             insertZkNode(ruleRealPath, data);
+            LOG.debug("created path: {} with data: {}", ruleRealPath, data);
         }
     }
 
     private void insertZkNode(final String path, final Object data) {
-        zkClient.createOrUpdate(path, data, CreateMode.PERSISTENT);
-    }
-
-    private void createZkNode(final String path) {
-        if (!zkClient.isExist(path)) {
-            zkClient.createOrUpdate(path, "", CreateMode.PERSISTENT);
+        try {
+            zkClient.createOrUpdate(path, data, CreateMode.PERSISTENT);
+        } catch (ShenyuException e) {
+            LOG.warn("node already exist, could be ignore.");
         }
     }
 

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedListener.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedListener.java
@@ -17,7 +17,6 @@
 
 package org.apache.shenyu.admin.listener.zookeeper;
 
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.shenyu.admin.listener.DataChangedListener;
 import org.apache.shenyu.common.constant.DefaultPathConstants;
@@ -28,7 +27,8 @@ import org.apache.shenyu.common.dto.RuleData;
 import org.apache.shenyu.common.dto.SelectorData;
 import org.apache.shenyu.common.enums.DataEventTypeEnum;
 import org.apache.shenyu.common.exception.ShenyuException;
-import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
+import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,9 +43,9 @@ public class ZookeeperDataChangedListener implements DataChangedListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZookeeperDataChangedListener.class);
 
-    private final ZkClient zkClient;
+    private final ZookeeperClient zkClient;
 
-    public ZookeeperDataChangedListener(final ZkClient zkClient) {
+    public ZookeeperDataChangedListener(final ZookeeperClient zkClient) {
         this.zkClient = zkClient;
     }
 
@@ -139,25 +139,24 @@ public class ZookeeperDataChangedListener implements DataChangedListener {
     }
 
     private void insertZkNode(final String path, final Object data) {
-        createZkNode(path);
-        zkClient.writeData(path, null == data ? "" : GsonUtils.getInstance().toJson(data));
+        zkClient.createOrUpdate(path, data, CreateMode.PERSISTENT);
     }
 
     private void createZkNode(final String path) {
-        if (!zkClient.exists(path)) {
-            zkClient.createPersistent(path, true);
+        if (!zkClient.isExist(path)) {
+            zkClient.createOrUpdate(path, "", CreateMode.PERSISTENT);
         }
     }
 
     private void deleteZkPath(final String path) {
-        if (zkClient.exists(path)) {
+        if (zkClient.isExist(path)) {
             zkClient.delete(path);
         }
     }
 
     private void deleteZkPathRecursive(final String path) {
-        if (zkClient.exists(path)) {
-            zkClient.deleteRecursive(path);
+        if (zkClient.isExist(path)) {
+            zkClient.delete(path);
         }
     }
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataInit.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataInit.java
@@ -17,10 +17,10 @@
 
 package org.apache.shenyu.admin.listener.zookeeper;
 
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.shenyu.admin.service.SyncDataService;
 import org.apache.shenyu.common.constant.DefaultPathConstants;
 import org.apache.shenyu.common.enums.DataEventTypeEnum;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
 import org.springframework.boot.CommandLineRunner;
 
 /**
@@ -28,7 +28,8 @@ import org.springframework.boot.CommandLineRunner;
  */
 public class ZookeeperDataInit implements CommandLineRunner {
 
-    private final ZkClient zkClient;
+//    private final ZkClient zkClient;
+    private final ZookeeperClient zkClient;
 
     private final SyncDataService syncDataService;
 
@@ -38,7 +39,7 @@ public class ZookeeperDataInit implements CommandLineRunner {
      * @param zkClient        the zk client
      * @param syncDataService the sync data service
      */
-    public ZookeeperDataInit(final ZkClient zkClient, final SyncDataService syncDataService) {
+    public ZookeeperDataInit(final ZookeeperClient zkClient, final SyncDataService syncDataService) {
         this.zkClient = zkClient;
         this.syncDataService = syncDataService;
     }
@@ -49,9 +50,9 @@ public class ZookeeperDataInit implements CommandLineRunner {
         String authPath = DefaultPathConstants.APP_AUTH_PARENT;
         String metaDataPath = DefaultPathConstants.META_DATA;
 
-        boolean zkPathNotExist = !zkClient.exists(pluginPath)
-                && !zkClient.exists(authPath)
-                && !zkClient.exists(metaDataPath);
+        boolean zkPathNotExist = !zkClient.isExist(pluginPath)
+                && !zkClient.isExist(authPath)
+                && !zkClient.isExist(metaDataPath);
 
         if (zkPathNotExist) {
             syncDataService.syncAll(DataEventTypeEnum.REFRESH);

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/config/DataSyncConfigurationTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/config/DataSyncConfigurationTest.java
@@ -20,7 +20,6 @@ package org.apache.shenyu.admin.config;
 
 import com.alibaba.nacos.client.config.NacosConfigService;
 import com.ecwid.consul.v1.ConsulClient;
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.curator.test.TestingServer;
 import org.apache.shenyu.admin.AbstractConfigurationTest;
 import org.apache.shenyu.admin.config.properties.ConsulProperties;
@@ -33,6 +32,8 @@ import org.apache.shenyu.admin.service.SelectorService;
 import org.apache.shenyu.admin.service.SyncDataService;
 import org.apache.shenyu.admin.service.impl.AppAuthServiceImpl;
 import org.apache.shenyu.admin.service.impl.SyncDataServiceImpl;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -44,7 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,7 +58,7 @@ public final class DataSyncConfigurationTest extends AbstractConfigurationTest {
 
     private static TestingServer zkServer;
 
-    private final ZkClient zkClient = new ZkClient("127.0.0.1:21810");
+    private static ZookeeperClient zkClient;
 
     @InjectMocks
     private AppAuthServiceImpl appAuthService;
@@ -79,11 +80,14 @@ public final class DataSyncConfigurationTest extends AbstractConfigurationTest {
 
     @BeforeAll
     public static void setUpBeforeClass() throws Exception {
-        zkServer = new TestingServer(21810, true);
+        zkServer = new TestingServer();
+        ZookeeperConfig config = new ZookeeperConfig(zkServer.getConnectString());
+        zkClient = new ZookeeperClient(config);
     }
 
     @AfterAll
     public static void tearDown() throws Exception {
+        zkClient.close();
         zkServer.stop();
     }
 

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/config/ZookeeperConfigurationTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/config/ZookeeperConfigurationTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.shenyu.admin.config;
 
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.shenyu.admin.AbstractConfigurationTest;
 import org.apache.shenyu.admin.config.properties.ZookeeperProperties;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -32,55 +32,54 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Test case for ZookeeperConfiguration.
  */
 public final class ZookeeperConfigurationTest extends AbstractConfigurationTest {
-    
-    private static final ZkClient ZK_CLIENT = Mockito.mock(ZkClient.class);
-    
+
+    private static final ZookeeperClient ZK_CLIENT = Mockito.mock(ZookeeperClient.class);
+
     private final String[] inlinedProperties = new String[]{
         "shenyu.sync.zookeeper.url=127.0.0.1:21810",
         "shenyu.sync.zookeeper.sessionTimeout=5000",
         "shenyu.sync.zookeeper.connectionTimeout=2000",
-        "shenyu.sync.zookeeper.serializer=org.I0Itec.zkclient.serialize.SerializableSerializer",
     };
-    
+
     @Test
     public void testOnMissingBean() {
         // init zkClient by ZookeeperConfiguration
         load(MockZookeeperConfiguration.class, inlinedProperties);
-        ZkClient zkClient = (ZkClient) getContext().getBean("zkClient");
+        ZookeeperClient zkClient = (ZookeeperClient) getContext().getBean("zookeeperClient");
         assertNotNull(zkClient);
     }
-    
+
     @Test
     public void testOnExistBean() {
         // verify zkClient by ZookeeperConfiguration
         load(CustomZkClientConfiguration.class, inlinedProperties);
         boolean isExistZkClient = getContext().containsBean("zkClient");
         assertFalse(isExistZkClient);
-        
+
         // get customZkClient
-        ZkClient customZkClient = (ZkClient) getContext().getBean("customZkClient");
+        ZookeeperClient customZkClient = (ZookeeperClient) getContext().getBean("customZkClient");
         assertNotNull(customZkClient);
     }
-    
+
     @EnableConfigurationProperties(ZookeeperProperties.class)
     static class MockZookeeperConfiguration extends ZookeeperConfiguration {
         /**
          * register zkClient in spring ioc.
          *
          * @param zookeeperProp the zookeeper configuration
-         * @return ZkClient {@linkplain ZkClient}
+         * @return ZkClient {@linkplain ZookeeperClient}
          */
         @Override
-        public ZkClient zkClient(final ZookeeperProperties zookeeperProp) {
+        public ZookeeperClient zookeeperClient(final ZookeeperProperties zookeeperProp) {
             return ZK_CLIENT;
         }
     }
-    
+
     @EnableConfigurationProperties(ZookeeperProperties.class)
     static class CustomZkClientConfiguration {
-        
+
         @Bean
-        public ZkClient customZkClient(final ZookeeperProperties zookeeperProp) {
+        public ZookeeperClient customZkClient(final ZookeeperProperties zookeeperProp) {
             return ZK_CLIENT;
         }
     }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/config/ZookeeperPropertiesTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/config/ZookeeperPropertiesTest.java
@@ -36,19 +36,16 @@ public final class ZookeeperPropertiesTest extends AbstractConfigurationTest {
         final String url = "127.0.0.1:2181";
         final Integer sessionTimeOut = 5000;
         final Integer connectionTimeout = 2000;
-        final String serializer = "org.I0Itec.zkclient.serialize.SerializableSerializer";
         final String[] inlinedProperties = new String[]{
             "shenyu.sync.zookeeper.url=" + url,
             "shenyu.sync.zookeeper.sessionTimeout=" + sessionTimeOut,
             "shenyu.sync.zookeeper.connectionTimeout=" + connectionTimeout,
-            "shenyu.sync.zookeeper.serializer=" + serializer,
         };
         load(ZookeeperPropertiesConfiguration.class, inlinedProperties);
         ZookeeperProperties properties = getContext().getBean(ZookeeperProperties.class);
         assertThat(properties.getUrl(), is(url));
         assertThat(properties.getSessionTimeout(), is(sessionTimeOut));
         assertThat(properties.getConnectionTimeout(), is(connectionTimeout));
-        assertThat(properties.getSerializer(), is(serializer));
     }
 
     @Configuration

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/zookeeper/HttpServiceDiscoveryTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/zookeeper/HttpServiceDiscoveryTest.java
@@ -17,23 +17,22 @@
 
 package org.apache.shenyu.admin.listener.zookeeper;
 
-import org.I0Itec.zkclient.ZkClient;
+import org.apache.curator.test.TestingServer;
 import org.apache.shenyu.admin.mapper.SelectorMapper;
 import org.apache.shenyu.admin.model.entity.SelectorDO;
 import org.apache.shenyu.admin.service.SelectorService;
 import org.apache.shenyu.common.dto.SelectorData;
-import org.assertj.core.util.Lists;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
+import org.apache.zookeeper.CreateMode;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.env.Environment;
 
-import java.util.List;
+import java.lang.reflect.Field;
 
 import static org.apache.shenyu.admin.listener.zookeeper.HttpServiceDiscovery.ROOT;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -43,7 +42,7 @@ import static org.mockito.Mockito.when;
 public final class HttpServiceDiscoveryTest {
 
     @Test
-    public void testAfterPropertiesSet() {
+    public void testAfterPropertiesSet() throws Exception {
         SelectorService selectorService = mock(SelectorService.class);
         SelectorMapper selectorMapper = mock(SelectorMapper.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
@@ -52,24 +51,26 @@ public final class HttpServiceDiscoveryTest {
         SelectorData selectorData = mock(SelectorData.class);
         when(selectorService.findByName(anyString())).thenReturn(selector);
         when(selectorService.buildByName(anyString())).thenReturn(selectorData);
-        when(env.getProperty("shenyu.http.register", Boolean.class, false)).thenReturn(false, true);
+        when(env.getProperty("shenyu.http.register", Boolean.class, false)).thenReturn(true);
+
+        TestingServer server = new TestingServer();
+        when(env.getProperty("shenyu.http.zookeeperUrl", "")).thenReturn(server.getConnectString());
+
         HttpServiceDiscovery discovery = new HttpServiceDiscovery(selectorService, selectorMapper, eventPublisher, env);
-        HttpServiceDiscovery spy = spy(discovery);
-        spy.afterPropertiesSet();
-        verify(env).getProperty("shenyu.http.register", Boolean.class, false);
-        String zookeeperUrl = "192.168.0.10:2181";
-        when(env.getProperty("shenyu.http.zookeeperUrl", "")).thenReturn(zookeeperUrl);
-        ZkClient zkClient = mock(ZkClient.class);
-        doReturn(zkClient).when(spy).createZkClient(zookeeperUrl);
-        when(zkClient.exists(ROOT)).thenReturn(false);
+
+        Class<? extends HttpServiceDiscovery> clazz = discovery.getClass();
+
         String server1 = "server1";
-        List<String> contextPathList = Lists.newArrayList(server1);
-        when(zkClient.getChildren(ROOT)).thenReturn(contextPathList);
-        when(zkClient.getChildren(ROOT + "/" + server1)).thenReturn(contextPathList);
-        when(zkClient.readData(anyString())).thenReturn("192.169.0.9");
-        spy.afterPropertiesSet();
-        verify(zkClient).createPersistent(ROOT, true);
-        verify(zkClient).getChildren(ROOT);
+        discovery.afterPropertiesSet();
+
+        String fieldString = "zkClient";
+        Field field = clazz.getDeclaredField(fieldString);
+        field.setAccessible(true);
+        ZookeeperClient zkClient = (ZookeeperClient) field.get(discovery);
+        zkClient.createOrUpdate(ROOT + "/" + server1 + "/hello", "", CreateMode.PERSISTENT);
+
+        // wait for take effect
+        Thread.sleep(500);
         verify(selectorMapper).updateSelective(selector);
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedListenerTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedListenerTest.java
@@ -19,7 +19,11 @@ package org.apache.shenyu.admin.listener.zookeeper;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.shenyu.common.constant.DefaultPathConstants;
-import org.apache.shenyu.common.dto.*;
+import org.apache.shenyu.common.dto.AppAuthData;
+import org.apache.shenyu.common.dto.MetaData;
+import org.apache.shenyu.common.dto.PluginData;
+import org.apache.shenyu.common.dto.RuleData;
+import org.apache.shenyu.common.dto.SelectorData;
 import org.apache.shenyu.common.enums.DataEventTypeEnum;
 import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
 import org.apache.zookeeper.CreateMode;

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedListenerTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedListenerTest.java
@@ -18,15 +18,11 @@
 package org.apache.shenyu.admin.listener.zookeeper;
 
 import com.google.common.collect.ImmutableList;
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.shenyu.common.constant.DefaultPathConstants;
-import org.apache.shenyu.common.dto.AppAuthData;
-import org.apache.shenyu.common.dto.MetaData;
-import org.apache.shenyu.common.dto.PluginData;
-import org.apache.shenyu.common.dto.RuleData;
-import org.apache.shenyu.common.dto.SelectorData;
+import org.apache.shenyu.common.dto.*;
 import org.apache.shenyu.common.enums.DataEventTypeEnum;
-import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
+import org.apache.zookeeper.CreateMode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -36,7 +32,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -69,7 +64,7 @@ public final class ZookeeperDataChangedListenerTest {
     private ZookeeperDataChangedListener zookeeperDataChangedListener;
 
     @Mock
-    private ZkClient zkClient;
+    private ZookeeperClient zkClient;
 
     /**
      * test case onAppAuthChanged create event.
@@ -79,10 +74,8 @@ public final class ZookeeperDataChangedListenerTest {
         AppAuthData appAuthData = AppAuthData.builder().appKey(MOCK_APP_KEY).appSecret(MOCK_APP_SECRET).build();
         String appAuthPath = DefaultPathConstants.buildAppAuthPath(appAuthData.getAppKey());
 
-        when(zkClient.exists(appAuthPath)).thenReturn(false);
         zookeeperDataChangedListener.onAppAuthChanged(ImmutableList.of(appAuthData), DataEventTypeEnum.CREATE);
-        verify(zkClient, times(1)).createPersistent(appAuthPath, true);
-        verify(zkClient, times(1)).writeData(appAuthPath, GsonUtils.getInstance().toJson(appAuthData));
+        verify(zkClient, times(1)).createOrUpdate(appAuthPath, appAuthData, CreateMode.PERSISTENT);
     }
 
     /**
@@ -93,10 +86,8 @@ public final class ZookeeperDataChangedListenerTest {
         AppAuthData appAuthData = AppAuthData.builder().appKey(MOCK_APP_KEY).appSecret(MOCK_APP_SECRET).build();
         String appAuthPath = DefaultPathConstants.buildAppAuthPath(appAuthData.getAppKey());
 
-        when(zkClient.exists(appAuthPath)).thenReturn(true);
         zookeeperDataChangedListener.onAppAuthChanged(ImmutableList.of(appAuthData), DataEventTypeEnum.UPDATE);
-        verify(zkClient, atMostOnce()).createPersistent(appAuthPath, true);
-        verify(zkClient, times(1)).writeData(appAuthPath, GsonUtils.getInstance().toJson(appAuthData));
+        verify(zkClient, times(1)).createOrUpdate(appAuthPath, appAuthData, CreateMode.PERSISTENT);
     }
 
     /**
@@ -107,7 +98,7 @@ public final class ZookeeperDataChangedListenerTest {
         AppAuthData appAuthData = AppAuthData.builder().appKey(MOCK_APP_KEY).appSecret(MOCK_APP_SECRET).build();
         String appAuthPath = DefaultPathConstants.buildAppAuthPath(appAuthData.getAppKey());
 
-        when(zkClient.exists(appAuthPath)).thenReturn(true);
+        when(zkClient.isExist(appAuthPath)).thenReturn(true);
         zookeeperDataChangedListener.onAppAuthChanged(ImmutableList.of(appAuthData), DataEventTypeEnum.DELETE);
         verify(zkClient, times(1)).delete(appAuthPath);
     }
@@ -120,10 +111,8 @@ public final class ZookeeperDataChangedListenerTest {
         MetaData metaData = MetaData.builder().id(MOCK_ID).path(MOCK_PATH).appName(MOCK_APP_NAME).build();
         String metaDataPath = DefaultPathConstants.buildMetaDataPath(URLEncoder.encode(metaData.getPath(), "UTF-8"));
 
-        when(zkClient.exists(metaDataPath)).thenReturn(false);
         zookeeperDataChangedListener.onMetaDataChanged(ImmutableList.of(metaData), DataEventTypeEnum.CREATE);
-        verify(zkClient, times(1)).createPersistent(metaDataPath, true);
-        verify(zkClient, times(1)).writeData(metaDataPath, GsonUtils.getInstance().toJson(metaData));
+        verify(zkClient, times(1)).createOrUpdate(metaDataPath, metaData, CreateMode.PERSISTENT);
     }
 
     /**
@@ -134,10 +123,8 @@ public final class ZookeeperDataChangedListenerTest {
         MetaData metaData = MetaData.builder().id(MOCK_ID).path(MOCK_PATH).appName(MOCK_APP_NAME).build();
         String metaDataPath = DefaultPathConstants.buildMetaDataPath(URLEncoder.encode(metaData.getPath(), "UTF-8"));
 
-        when(zkClient.exists(metaDataPath)).thenReturn(true);
         zookeeperDataChangedListener.onMetaDataChanged(ImmutableList.of(metaData), DataEventTypeEnum.UPDATE);
-        verify(zkClient, atMostOnce()).createPersistent(metaDataPath, true);
-        verify(zkClient, times(1)).writeData(metaDataPath, GsonUtils.getInstance().toJson(metaData));
+        verify(zkClient, times(1)).createOrUpdate(metaDataPath, metaData, CreateMode.PERSISTENT);
     }
 
     /**
@@ -148,7 +135,7 @@ public final class ZookeeperDataChangedListenerTest {
         MetaData metaData = MetaData.builder().id(MOCK_ID).path(MOCK_PATH).appName(MOCK_APP_NAME).build();
         String metaDataPath = DefaultPathConstants.buildMetaDataPath(URLEncoder.encode(metaData.getPath(), "UTF-8"));
 
-        when(zkClient.exists(metaDataPath)).thenReturn(true);
+        when(zkClient.isExist(metaDataPath)).thenReturn(true);
         zookeeperDataChangedListener.onMetaDataChanged(ImmutableList.of(metaData), DataEventTypeEnum.DELETE);
         verify(zkClient, times(1)).delete(metaDataPath);
     }
@@ -161,10 +148,8 @@ public final class ZookeeperDataChangedListenerTest {
         PluginData pluginData = PluginData.builder().id(MOCK_ID).name(MOCK_NAME).config(MOCK_CONFIG).build();
         String pluginPath = DefaultPathConstants.buildPluginPath(pluginData.getName());
 
-        when(zkClient.exists(pluginPath)).thenReturn(false);
         zookeeperDataChangedListener.onPluginChanged(ImmutableList.of(pluginData), DataEventTypeEnum.CREATE);
-        verify(zkClient, times(1)).createPersistent(pluginPath, true);
-        verify(zkClient, times(1)).writeData(pluginPath, GsonUtils.getInstance().toJson(pluginData));
+        verify(zkClient, times(1)).createOrUpdate(pluginPath, pluginData, CreateMode.PERSISTENT);
     }
 
     /**
@@ -175,10 +160,8 @@ public final class ZookeeperDataChangedListenerTest {
         PluginData pluginData = PluginData.builder().id(MOCK_ID).name(MOCK_NAME).config(MOCK_CONFIG).build();
         String pluginPath = DefaultPathConstants.buildPluginPath(pluginData.getName());
 
-        when(zkClient.exists(pluginPath)).thenReturn(true);
         zookeeperDataChangedListener.onPluginChanged(ImmutableList.of(pluginData), DataEventTypeEnum.UPDATE);
-        verify(zkClient, atMostOnce()).createPersistent(pluginPath, true);
-        verify(zkClient, times(1)).writeData(pluginPath, GsonUtils.getInstance().toJson(pluginData));
+        verify(zkClient, times(1)).createOrUpdate(pluginPath, pluginData, CreateMode.PERSISTENT);
     }
 
     /**
@@ -191,14 +174,14 @@ public final class ZookeeperDataChangedListenerTest {
         String selectorParentPath = DefaultPathConstants.buildSelectorParentPath(pluginData.getName());
         String ruleParentPath = DefaultPathConstants.buildRuleParentPath(pluginData.getName());
 
-        when(zkClient.exists(pluginPath)).thenReturn(true);
-        when(zkClient.exists(selectorParentPath)).thenReturn(true);
-        when(zkClient.exists(ruleParentPath)).thenReturn(true);
+        when(zkClient.isExist(pluginPath)).thenReturn(true);
+        when(zkClient.isExist(selectorParentPath)).thenReturn(true);
+        when(zkClient.isExist(ruleParentPath)).thenReturn(true);
 
         zookeeperDataChangedListener.onPluginChanged(ImmutableList.of(pluginData), DataEventTypeEnum.DELETE);
-        verify(zkClient, times(1)).deleteRecursive(pluginPath);
-        verify(zkClient, times(1)).deleteRecursive(selectorParentPath);
-        verify(zkClient, times(1)).deleteRecursive(ruleParentPath);
+        verify(zkClient, times(1)).delete(pluginPath);
+        verify(zkClient, times(1)).delete(selectorParentPath);
+        verify(zkClient, times(1)).delete(ruleParentPath);
     }
 
     /**
@@ -209,15 +192,9 @@ public final class ZookeeperDataChangedListenerTest {
         SelectorData selectorData = SelectorData.builder().id(MOCK_ID).name(MOCK_NAME).pluginName(MOCK_PLUGIN_NAME).build();
 
         String selectorRealPath = DefaultPathConstants.buildSelectorRealPath(selectorData.getPluginName(), selectorData.getId());
-        String selectorParentPath = DefaultPathConstants.buildSelectorParentPath(selectorData.getPluginName());
-
-        when(zkClient.exists(selectorRealPath)).thenReturn(false);
-        when(zkClient.exists(selectorParentPath)).thenReturn(false);
 
         zookeeperDataChangedListener.onSelectorChanged(ImmutableList.of(selectorData), DataEventTypeEnum.CREATE);
-        verify(zkClient, times(1)).createPersistent(selectorRealPath, true);
-        verify(zkClient, times(1)).createPersistent(selectorParentPath, true);
-        verify(zkClient, times(1)).writeData(selectorRealPath, GsonUtils.getInstance().toJson(selectorData));
+        verify(zkClient, times(1)).createOrUpdate(selectorRealPath, selectorData, CreateMode.PERSISTENT);
     }
 
     /**
@@ -228,15 +205,9 @@ public final class ZookeeperDataChangedListenerTest {
         SelectorData selectorData = SelectorData.builder().id(MOCK_ID).name(MOCK_NAME).pluginName(MOCK_PLUGIN_NAME).build();
 
         String selectorRealPath = DefaultPathConstants.buildSelectorRealPath(selectorData.getPluginName(), selectorData.getId());
-        String selectorParentPath = DefaultPathConstants.buildSelectorParentPath(selectorData.getPluginName());
-
-        when(zkClient.exists(selectorRealPath)).thenReturn(true);
-        when(zkClient.exists(selectorParentPath)).thenReturn(true);
 
         zookeeperDataChangedListener.onSelectorChanged(ImmutableList.of(selectorData), DataEventTypeEnum.UPDATE);
-        verify(zkClient, atMostOnce()).createPersistent(selectorRealPath, true);
-        verify(zkClient, atMostOnce()).createPersistent(selectorParentPath, true);
-        verify(zkClient, times(1)).writeData(selectorRealPath, GsonUtils.getInstance().toJson(selectorData));
+        verify(zkClient, times(1)).createOrUpdate(selectorRealPath, selectorData, CreateMode.PERSISTENT);
     }
 
     /**
@@ -247,9 +218,9 @@ public final class ZookeeperDataChangedListenerTest {
         SelectorData selectorData = SelectorData.builder().id(MOCK_ID).name(MOCK_NAME).pluginName(MOCK_PLUGIN_NAME).build();
         String selectorParentPath = DefaultPathConstants.buildSelectorParentPath(selectorData.getPluginName());
 
-        when(zkClient.exists(selectorParentPath)).thenReturn(true);
+        when(zkClient.isExist(selectorParentPath)).thenReturn(true);
         zookeeperDataChangedListener.onSelectorChanged(ImmutableList.of(selectorData), DataEventTypeEnum.REFRESH);
-        verify(zkClient, times(1)).deleteRecursive(selectorParentPath);
+        verify(zkClient, times(1)).delete(selectorParentPath);
     }
 
     /**
@@ -260,7 +231,7 @@ public final class ZookeeperDataChangedListenerTest {
         SelectorData selectorData = SelectorData.builder().id(MOCK_ID).name(MOCK_NAME).pluginName(MOCK_PLUGIN_NAME).build();
         String selectorRealPath = DefaultPathConstants.buildSelectorRealPath(selectorData.getPluginName(), selectorData.getId());
 
-        when(zkClient.exists(selectorRealPath)).thenReturn(true);
+        when(zkClient.isExist(selectorRealPath)).thenReturn(true);
         zookeeperDataChangedListener.onSelectorChanged(ImmutableList.of(selectorData), DataEventTypeEnum.DELETE);
         verify(zkClient, times(1)).delete(selectorRealPath);
     }
@@ -277,15 +248,9 @@ public final class ZookeeperDataChangedListenerTest {
                 .selectorId(MOCK_SELECTOR_ID)
                 .build();
         String ruleRealPath = DefaultPathConstants.buildRulePath(ruleData.getPluginName(), ruleData.getSelectorId(), ruleData.getId());
-        String ruleParentPath = DefaultPathConstants.buildRuleParentPath(ruleData.getPluginName());
-
-        when(zkClient.exists(ruleRealPath)).thenReturn(false);
-        when(zkClient.exists(ruleParentPath)).thenReturn(false);
 
         zookeeperDataChangedListener.onRuleChanged(ImmutableList.of(ruleData), DataEventTypeEnum.CREATE);
-        verify(zkClient, times(1)).createPersistent(ruleRealPath, true);
-        verify(zkClient, times(1)).createPersistent(ruleParentPath, true);
-        verify(zkClient, times(1)).writeData(ruleRealPath, GsonUtils.getInstance().toJson(ruleData));
+        verify(zkClient, times(1)).createOrUpdate(ruleRealPath, ruleData, CreateMode.PERSISTENT);
     }
 
     /**
@@ -301,15 +266,9 @@ public final class ZookeeperDataChangedListenerTest {
                 .build();
         String ruleRealPath = DefaultPathConstants.buildRulePath(ruleData.getPluginName(), ruleData.getSelectorId(),
                 ruleData.getId());
-        String ruleParentPath = DefaultPathConstants.buildRuleParentPath(ruleData.getPluginName());
-
-        when(zkClient.exists(ruleRealPath)).thenReturn(true);
-        when(zkClient.exists(ruleParentPath)).thenReturn(true);
 
         zookeeperDataChangedListener.onRuleChanged(ImmutableList.of(ruleData), DataEventTypeEnum.UPDATE);
-        verify(zkClient, atMostOnce()).createPersistent(ruleRealPath, true);
-        verify(zkClient, atMostOnce()).createPersistent(ruleParentPath, true);
-        verify(zkClient, times(1)).writeData(ruleRealPath, GsonUtils.getInstance().toJson(ruleData));
+        verify(zkClient, times(1)).createOrUpdate(ruleRealPath, ruleData, CreateMode.PERSISTENT);
     }
 
     /**
@@ -325,9 +284,9 @@ public final class ZookeeperDataChangedListenerTest {
                 .build();
         String ruleParentPath = DefaultPathConstants.buildRuleParentPath(ruleData.getPluginName());
 
-        when(zkClient.exists(ruleParentPath)).thenReturn(true);
+        when(zkClient.isExist(ruleParentPath)).thenReturn(true);
         zookeeperDataChangedListener.onRuleChanged(ImmutableList.of(ruleData), DataEventTypeEnum.REFRESH);
-        verify(zkClient, times(1)).deleteRecursive(ruleParentPath);
+        verify(zkClient, times(1)).delete(ruleParentPath);
     }
 
     /**
@@ -343,7 +302,7 @@ public final class ZookeeperDataChangedListenerTest {
                 .build();
         String ruleRealPath = DefaultPathConstants.buildRulePath(ruleData.getPluginName(), ruleData.getSelectorId(), ruleData.getId());
 
-        when(zkClient.exists(ruleRealPath)).thenReturn(true);
+        when(zkClient.isExist(ruleRealPath)).thenReturn(true);
         zookeeperDataChangedListener.onRuleChanged(ImmutableList.of(ruleData), DataEventTypeEnum.DELETE);
         verify(zkClient, times(1)).delete(ruleRealPath);
     }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataInitTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataInitTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.shenyu.admin.listener.zookeeper;
 
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.shenyu.admin.service.SyncDataService;
 import org.apache.shenyu.common.constant.DefaultPathConstants;
+import org.apache.shenyu.register.client.server.zookeeper.ZookeeperClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
 public final class ZookeeperDataInitTest {
 
     @Mock
-    private ZkClient zkClient;
+    private ZookeeperClient zkClient;
 
     @Mock
     private SyncDataService syncDataService;
@@ -50,16 +50,16 @@ public final class ZookeeperDataInitTest {
     public void testRun() {
         ZookeeperDataInit zookeeperDataInit = new ZookeeperDataInit(zkClient, syncDataService);
 
-        when(zkClient.exists(Mockito.anyString())).thenReturn(false);
+        when(zkClient.isExist(Mockito.anyString())).thenReturn(false);
         zookeeperDataInit.run();
 
-        when(zkClient.exists(Mockito.anyString()))
+        when(zkClient.isExist(Mockito.anyString()))
                 .then(invocation -> pathExist(invocation, Collections.singletonList(
                         DefaultPathConstants.APP_AUTH_PARENT
                 )));
         zookeeperDataInit.run();
 
-        when(zkClient.exists(Mockito.anyString()))
+        when(zkClient.isExist(Mockito.anyString()))
                 .thenAnswer(invocation -> pathExist(invocation, Arrays.asList(
                         DefaultPathConstants.PLUGIN_PARENT,
                         DefaultPathConstants.APP_AUTH_PARENT

--- a/shenyu-bootstrap/pom.xml
+++ b/shenyu-bootstrap/pom.xml
@@ -26,7 +26,6 @@
     <artifactId>shenyu-bootstrap</artifactId>
 
     <properties>
-        <curator.version>4.0.1</curator.version>
         <spring-cloud.version>2.2.0.RELEASE</spring-cloud.version>
         <nacos-discovery.version>2.2.6.RELEASE</nacos-discovery.version>
         <eureka-client.version>2.1.2.RELEASE</eureka-client.version>
@@ -298,28 +297,7 @@
             <version>1.1.4</version>
         </dependency>-->
         <!-- Dubbo zookeeper registry dependency start -->
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-client</artifactId>
-            <version>4.0.1</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>log4j</artifactId>
-                    <groupId>log4j</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-framework</artifactId>
-            <version>4.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-recipes</artifactId>
-            <version>4.0.1</version>
-        </dependency>
-        <!-- Dubbo zookeeper registry dependency end -->
+       <!-- Dubbo zookeeper registry dependency end -->
         <!-- shenyu  apache dubbo plugin end-->
 
         <!--shenyu alibaba dubbo plugin start-->

--- a/shenyu-common/pom.xml
+++ b/shenyu-common/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>commons-collections4</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/shenyu-common/pom.xml
+++ b/shenyu-common/pom.xml
@@ -72,13 +72,10 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-
 </project>

--- a/shenyu-common/pom.xml
+++ b/shenyu-common/pom.xml
@@ -63,19 +63,5 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-framework</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-recipes</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-test</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/shenyu-common/pom.xml
+++ b/shenyu-common/pom.xml
@@ -73,6 +73,12 @@
             <artifactId>curator-recipes</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/shenyu-common/pom.xml
+++ b/shenyu-common/pom.xml
@@ -68,6 +68,10 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/client/zookeeper/ZookeeperClient.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/client/zookeeper/ZookeeperClient.java
@@ -127,14 +127,11 @@ public class ZookeeperClient {
      */
     public String get(final String key) {
         CuratorCache cache = findFromcache(key);
+        if (Objects.isNull(cache)) {
+            return getDirectly(key);
+        }
         Optional<ChildData> data = cache.get(key);
-        if (Objects.isNull(cache) || !data.isPresent()) {
-            return getDirectly(key);
-        }
-        if (Objects.isNull(data.get())) {
-            return getDirectly(key);
-        }
-        return new String(data.get().getData(), StandardCharsets.UTF_8);
+        return data.map(childData -> new String(childData.getData(), StandardCharsets.UTF_8)).orElseGet(() -> getDirectly(key));
     }
 
     /**

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/client/zookeeper/ZookeeperClient.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/client/zookeeper/ZookeeperClient.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.common.client.zookeeper;
+
+import com.google.common.base.Charsets;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.transaction.CuratorOp;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.shenyu.common.exception.ShenyuException;
+import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class ZookeeperClient {
+
+    private ZookeeperConfig config;
+
+    private CuratorFramework client;
+
+    public ZookeeperClient(final ZookeeperConfig zookeeperConfig) {
+        this.config = zookeeperConfig;
+        ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(config.getBaseSleepTimeMilliseconds(), config.getMaxRetries(), config.getMaxSleepTimeMilliseconds());
+
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
+                .connectString(config.getServerLists())
+                .retryPolicy(retryPolicy)
+                .connectionTimeoutMs(config.getConnectionTimeoutMilliseconds())
+                .sessionTimeoutMs(config.getSessionTimeoutMilliseconds())
+                .namespace(config.getNamespace());
+
+        if (!StringUtils.isEmpty(config.getDigest())) {
+            builder.authorization("digest", config.getDigest().getBytes(StandardCharsets.UTF_8));
+        }
+
+        this.client = builder.build();
+    }
+
+    /**
+     * start.
+     */
+    public void start() {
+        this.client.start();
+    }
+
+    /**
+     * start.
+     */
+    public void close() {
+        CloseableUtils.closeQuietly(client);
+    }
+
+    /**
+     * get curator framework.
+     *
+     * @return curator framework client.
+     */
+    public CuratorFramework getClient() {
+        return client;
+    }
+
+    /**
+     * check if key exist.
+     *
+     * @param key zookeeper path
+     * @return if exist.
+     */
+    public boolean isExist(final String key) {
+        try {
+            return null != client.checkExists().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * create or update key with value.
+     *
+     * @param key   zookeeper path key.
+     * @param value string value.
+     * @param mode  creation mode.
+     */
+    public void createOrUpdate(final String key, final String value, final CreateMode mode) {
+        String val = StringUtils.isEmpty(value) ? "" : value;
+        try {
+            client.create().orSetData().creatingParentsIfNeeded().withMode(mode).forPath(key, val.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * create or update key with value.
+     *
+     * @param key   zookeeper path key.
+     * @param value object value.
+     * @param mode  creation mode.
+     */
+    public void createOrUpdate(final String key, final Object value, final CreateMode mode) {
+        if (value != null) {
+            String val = GsonUtils.getInstance().toJson(value);
+            createOrUpdate(key, val, mode);
+        } else {
+            createOrUpdate(key, "", mode);
+        }
+    }
+
+    /**
+     * delete a node with specific key.
+     *
+     * @param key zookeeper path key.
+     */
+    public void delete(final String key) {
+        try {
+            client.delete().deletingChildrenIfNeeded().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get children with specific key.
+     *
+     * @param key zookeeper key.
+     * @return children node name.
+     */
+    public List<String> getChildren(final String key) {
+        try {
+            return client.getChildren().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+}

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/client/zookeeper/ZookeeperConfig.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/client/zookeeper/ZookeeperConfig.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.common.client.zookeeper;
+
+public class ZookeeperConfig {
+    /**
+     * zookeeper server list.
+     * e.g. host1:2181,host2:2181
+     */
+    private final String serverLists;
+
+    /**
+     * zookeeper namespace.
+     */
+    private String namespace = "";
+
+    /**
+     * initial amount of time to wait between retries.
+     */
+    private int baseSleepTimeMilliseconds = 1000;
+
+    /**
+     * max time in ms to sleep on each retry.
+     */
+    private int maxSleepTimeMilliseconds = Integer.MAX_VALUE;
+
+    /**
+     * max number of times to retry.
+     */
+    private int maxRetries = 3;
+
+    /**
+     * session timeout.
+     */
+    private int sessionTimeoutMilliseconds;
+
+    /**
+     * connection timeout.
+     */
+    private int connectionTimeoutMilliseconds;
+
+    /**
+     * auth token digest. no auth by default.
+     */
+    private String digest;
+
+    public ZookeeperConfig(final String serverLists) {
+        this.serverLists = serverLists;
+    }
+
+    /**
+     * get zookeeper server list.
+     * @return server list.
+     */
+    public String getServerLists() {
+        return serverLists;
+    }
+
+    /**
+     * set namespace.
+     * @param namespace zk namespace
+     * @return zk config
+     */
+    public ZookeeperConfig setNamespace(final String namespace) {
+        this.namespace = namespace;
+        return this;
+    }
+
+    /**
+     * get namespace.
+     * @return namespace
+     */
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * get base sleep time.
+     * @return base sleep time.
+     */
+    public int getBaseSleepTimeMilliseconds() {
+        return baseSleepTimeMilliseconds;
+    }
+
+    /**
+     * set base sleep time.
+     * @param baseSleepTimeMilliseconds base sleep time in milliseconds.
+     * @return zk config.
+     */
+    public ZookeeperConfig setBaseSleepTimeMilliseconds(final int baseSleepTimeMilliseconds) {
+        this.baseSleepTimeMilliseconds = baseSleepTimeMilliseconds;
+        return this;
+    }
+
+    /**
+     * get max sleep time.
+     * @return max sleep time
+     */
+    public int getMaxSleepTimeMilliseconds() {
+        return maxSleepTimeMilliseconds;
+    }
+
+    /**
+     * set max sleep time.
+     * @param maxSleepTimeMilliseconds max sleep time.
+     * @return zk config.
+     */
+    public ZookeeperConfig setMaxSleepTimeMilliseconds(final int maxSleepTimeMilliseconds) {
+        this.maxSleepTimeMilliseconds = maxSleepTimeMilliseconds;
+        return this;
+    }
+
+    /**
+     * get max retries.
+     * @return max retries
+     */
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    /**
+     * set max retries count.
+     * @param maxRetries max retries
+     * @return zk config.
+     */
+    public ZookeeperConfig setMaxRetries(final int maxRetries) {
+        this.maxRetries = maxRetries;
+        return this;
+    }
+
+    /**
+     * get session timeout in milliseconds.
+     * @return session timeout.
+     */
+    public int getSessionTimeoutMilliseconds() {
+        return sessionTimeoutMilliseconds;
+    }
+
+    /**
+     * set session timeout in milliseconds.
+     * @param sessionTimeoutMilliseconds session timeout
+     * @return zk config.
+     */
+    public ZookeeperConfig setSessionTimeoutMilliseconds(final int sessionTimeoutMilliseconds) {
+        this.sessionTimeoutMilliseconds = sessionTimeoutMilliseconds;
+        return this;
+    }
+
+    /**
+     * get connection timeout in milliseconds.
+     * @return connection timeout.
+     */
+    public int getConnectionTimeoutMilliseconds() {
+        return connectionTimeoutMilliseconds;
+    }
+
+    /**
+     * set connection timeout in milliseconds.
+     * @param connectionTimeoutMilliseconds connection timeout.
+     * @return zk config.
+     */
+    public ZookeeperConfig setConnectionTimeoutMilliseconds(final int connectionTimeoutMilliseconds) {
+        this.connectionTimeoutMilliseconds = connectionTimeoutMilliseconds;
+        return this;
+    }
+
+    /**
+     * get digest.
+     * @return digest.
+     */
+    public String getDigest() {
+        return digest;
+    }
+
+    /**
+     * set digest.
+     * @param digest digest
+     * @return zk config.
+     */
+    public ZookeeperConfig setDigest(final String digest) {
+        this.digest = digest;
+        return this;
+    }
+}

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/client/zookeeper/ZookeeperConfig.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/client/zookeeper/ZookeeperConfig.java
@@ -47,12 +47,12 @@ public class ZookeeperConfig {
     /**
      * session timeout.
      */
-    private int sessionTimeoutMilliseconds;
+    private int sessionTimeoutMilliseconds = 60 * 1000;
 
     /**
      * connection timeout.
      */
-    private int connectionTimeoutMilliseconds;
+    private int connectionTimeoutMilliseconds = 15 * 1000;
 
     /**
      * auth token digest. no auth by default.

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/client/zookeeper/ZookeeperClientTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/client/zookeeper/ZookeeperClientTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.common.client.zookeeper;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.test.TestingServer;
+import org.apache.shenyu.common.dto.MetaData;
+import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ZookeeperClientTest {
+
+    private ZookeeperClient client;
+
+    private TestingServer server;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        this.server = new TestingServer();
+        ZookeeperConfig config = new ZookeeperConfig(server.getConnectString());
+        client = new ZookeeperClient(config);
+        client.start();
+    }
+
+    @AfterEach
+    public void cleanup() throws IOException {
+        client.close();
+        this.server.close();
+    }
+
+    @Test
+    void getClient() {
+        CuratorFramework curatorFramework = client.getClient();
+        assertNotNull(curatorFramework);
+    }
+
+    @Test
+    void isExist() {
+        boolean exist = client.isExist("/test");
+        assertFalse(exist);
+
+        client.createOrUpdate("/test", "", CreateMode.PERSISTENT);
+        exist = client.isExist("/test");
+        assertTrue(exist);
+    }
+
+    @Test
+    void getDirectly() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.getDirectly("/test");
+        assertEquals("hello", val);
+    }
+
+    @Test
+    void get() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals("hello", val);
+    }
+
+    @Test
+    void createOrUpdate() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals("hello", val);
+    }
+
+    @Test
+    void testCreateOrUpdate() {
+        MetaData data = new MetaData();
+        data.setAppName("test");
+        client.createOrUpdate("/test", data, CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals(GsonUtils.getInstance().toJson(data), val);
+    }
+
+    @Test
+    void delete() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals("hello", val);
+
+        client.delete("/test");
+        boolean exist = client.isExist("/test");
+        assertFalse(exist);
+    }
+
+    @Test
+    void getChildren() {
+        client.createOrUpdate("/test/1", "hello", CreateMode.PERSISTENT);
+        client.createOrUpdate("/test/2", "hello", CreateMode.PERSISTENT);
+
+        List<String> children = client.getChildren("/test");
+        assertTrue(children.contains("1"));
+        assertTrue(children.contains("2"));
+        assertEquals(2, children.size());
+    }
+
+    @Test
+    void getCache() {
+        CuratorCache cache = client.getCache("/test");
+        assertNull(cache);
+
+        client.addCache("/test");
+        cache = client.getCache("/test");
+        assertNotNull(cache);
+    }
+
+    @Test
+    void addCache() {
+        client.addCache("/test");
+        CuratorCache cache = client.getCache("/test");
+        assertNotNull(cache);
+    }
+}

--- a/shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE
+++ b/shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE
@@ -316,9 +316,11 @@ The text of each license is the standard Apache 2.0 license.
     tomcat-embed-el 9.0.29: https://tomcat.apache.org, Apache 2.0
     tomcat-embed-websocket 9.0.29: https://tomcat.apache.org, Apache 2.0
     unbescape 1.1.6.RELEASE: http://www.unbescape.org, Apache 2.0
-    zkclient 0.10: https://github.com/sgroschupf/zkclient, Apache 2.0
-    zookeeper 3.5.6: https://github.com/apache/zookeeper, Apache 2.0
-    zookeeper-jute 3.5.6: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper 3.6.3: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper-jute 3.6.3: https://github.com/apache/zookeeper, Apache 2.0
+    curator-client 5.2.1: https://github.com/apache/curator, Apache 2.0
+    curator-framework 5.2.1: https://github.com/apache/curator, Apache 2.0
+    curator-recipes 5.2.1: https://github.com/apache/curator, Apache 2.0
 
 ========================================================================
 BSD licenses

--- a/shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE
+++ b/shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE
@@ -236,9 +236,9 @@ The text of each license is the standard Apache 2.0 license.
     commons-jxpath 1.3: http://commons.apache.org/jxpath/, Apache 2.0
     commons-math 2.2: https://github.com/apache/commons-math, Apache 2.0
     conscrypt-openjdk-uber 2.5.1: https://conscrypt.org, Apache 2.0
-    curator-client 4.0.1:  https://github.com/apache/curator, Apache 2.0
-    curator-framework 4.0.1:  https://github.com/apache/curator, Apache 2.0
-    curator-recipes 4.0.1:  https://github.com/apache/curator, Apache 2.0
+    curator-client 5.2.1:  https://github.com/apache/curator, Apache 2.0
+    curator-framework 5.2.1:  https://github.com/apache/curator, Apache 2.0
+    curator-recipes 5.2.1:  https://github.com/apache/curator, Apache 2.0
     dubbo 2.6.5: https://github.com/apache/dubbo, Apache 2.0
     error_prone_annotations 2.5.1: https://github.com/google/error-prone, Apache 2.0
     failsafe 2.3.3: https://github.com/jhalterman/failsafe, Apache 2.0
@@ -353,8 +353,8 @@ The text of each license is the standard Apache 2.0 license.
     vavr 0.10.2: http://vavr.io, Apache 2.0
     vavr-match 0.10.2: http://vavr.io, Apache 2.0
     zkclient 0.10: https://github.com/sgroschupf/zkclient, Apache 2.0
-    zookeeper 3.5.6: https://github.com/apache/zookeeper, Apache 2.0
-    zookeeper-jute 3.5.6: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper 3.6.3: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper-jute 3.6.3: https://github.com/apache/zookeeper, Apache 2.0
     byte-buddy 1.12.6: https://github.com/raphw/byte-buddy, Apache 2.0
     byte-buddy-agent 1.12.6: https://github.com/raphw/byte-buddy, Apache 2.0
     disruptor 3.4.0 https://github.com/LMAX-Exchange/disruptor, Apache 2.0

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/pom.xml
@@ -46,6 +46,14 @@
 
         <dependency>
             <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/pom.xml
@@ -43,20 +43,5 @@
             <artifactId>shenyu-disruptor</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 </project>

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/pom.xml
@@ -43,5 +43,11 @@
             <artifactId>shenyu-disruptor</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/main/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperClient.java
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/main/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperClient.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.register.client.server.zookeeper;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.shenyu.common.exception.ShenyuException;
+import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.zookeeper.CreateMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ZookeeperClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperClient.class);
+
+    private final ZookeeperConfig config;
+
+    private final CuratorFramework client;
+
+    private final Map<String, CuratorCache> caches = new ConcurrentHashMap<>();
+
+    public ZookeeperClient(final ZookeeperConfig zookeeperConfig) {
+        this.config = zookeeperConfig;
+        ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(config.getBaseSleepTimeMilliseconds(), config.getMaxRetries(), config.getMaxSleepTimeMilliseconds());
+
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
+                .connectString(config.getServerLists())
+                .retryPolicy(retryPolicy)
+                .connectionTimeoutMs(config.getConnectionTimeoutMilliseconds())
+                .sessionTimeoutMs(config.getSessionTimeoutMilliseconds())
+                .namespace(config.getNamespace());
+
+        if (!StringUtils.isEmpty(config.getDigest())) {
+            builder.authorization("digest", config.getDigest().getBytes(StandardCharsets.UTF_8));
+        }
+
+        this.client = builder.build();
+    }
+
+    /**
+     * start.
+     */
+    public void start() {
+        this.client.start();
+        try {
+            this.client.blockUntilConnected();
+        } catch (InterruptedException e) {
+            LOGGER.warn("Interrupted during zookeeper client starting.");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * start.
+     */
+    public void close() {
+        // close all caches
+        for (Map.Entry<String, CuratorCache> cache : caches.entrySet()) {
+            CloseableUtils.closeQuietly(cache.getValue());
+        }
+        // close client
+        CloseableUtils.closeQuietly(client);
+    }
+
+    /**
+     * get curator framework.
+     *
+     * @return curator framework client.
+     */
+    public CuratorFramework getClient() {
+        return client;
+    }
+
+    /**
+     * check if key exist.
+     *
+     * @param key zookeeper path
+     * @return if exist.
+     */
+    public boolean isExist(final String key) {
+        try {
+            return null != client.checkExists().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get from zk directly.
+     *
+     * @param key zookeeper path
+     * @return value.
+     */
+    public String getDirectly(final String key) {
+        try {
+            byte[] ret = client.getData().forPath(key);
+            return Objects.isNull(ret) ? null : new String(ret, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get value for specific key.
+     *
+     * @param key zookeeper path
+     * @return value.
+     */
+    public String get(final String key) {
+        CuratorCache cache = findFromcache(key);
+        if (Objects.isNull(cache)) {
+            return getDirectly(key);
+        }
+        Optional<ChildData> data = cache.get(key);
+        return data.map(childData -> new String(childData.getData(), StandardCharsets.UTF_8)).orElseGet(() -> getDirectly(key));
+    }
+
+    /**
+     * create or update key with value.
+     *
+     * @param key   zookeeper path key.
+     * @param value string value.
+     * @param mode  creation mode.
+     */
+    public void createOrUpdate(final String key, final String value, final CreateMode mode) {
+        String val = StringUtils.isEmpty(value) ? "" : value;
+        try {
+            client.create().orSetData().creatingParentsIfNeeded().withMode(mode).forPath(key, val.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * create or update key with value.
+     *
+     * @param key   zookeeper path key.
+     * @param value object value.
+     * @param mode  creation mode.
+     */
+    public void createOrUpdate(final String key, final Object value, final CreateMode mode) {
+        if (value != null) {
+            String val = GsonUtils.getInstance().toJson(value);
+            createOrUpdate(key, val, mode);
+        } else {
+            createOrUpdate(key, "", mode);
+        }
+    }
+
+    /**
+     * delete a node with specific key.
+     *
+     * @param key zookeeper path key.
+     */
+    public void delete(final String key) {
+        try {
+            client.delete().deletingChildrenIfNeeded().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get children with specific key.
+     *
+     * @param key zookeeper key.
+     * @return children node name.
+     */
+    public List<String> getChildren(final String key) {
+        try {
+            return client.getChildren().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get created cache.
+     * @param path path.
+     * @return cache.
+     */
+    public CuratorCache getCache(final String path) {
+        return caches.get(path);
+    }
+
+    /**
+     * add new curator cache.
+     * @param path path.
+     * @param listeners listeners.
+     * @return cache.
+     */
+    public CuratorCache addCache(final String path, final CuratorCacheListener... listeners) {
+        CuratorCache cache = CuratorCache.build(client, path);
+        caches.put(path, cache);
+        if (listeners != null && listeners.length > 0) {
+            for (CuratorCacheListener listener : listeners) {
+                cache.listenable().addListener(listener);
+            }
+        }
+        cache.start();
+        return cache;
+    }
+
+    /**
+     * find cache with  key.
+     * @param key key.
+     * @return cache.
+     */
+    private CuratorCache findFromcache(final String key) {
+        for (Map.Entry<String, CuratorCache> cache : caches.entrySet()) {
+            if (key.startsWith(cache.getKey())) {
+                return cache.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/main/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperClientServerRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/main/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperClientServerRegisterRepository.java
@@ -22,8 +22,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
-import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
-import org.apache.shenyu.common.client.zookeeper.ZookeeperConfig;
 import org.apache.shenyu.common.constant.Constants;
 import org.apache.shenyu.common.enums.RpcTypeEnum;
 import org.apache.shenyu.common.utils.GsonUtils;

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/main/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperConfig.java
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/main/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperConfig.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shenyu.common.client.zookeeper;
+package org.apache.shenyu.register.client.server.zookeeper;
 
 public class ZookeeperConfig {
     /**

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/test/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperClientTest.java
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/test/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperClientTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.register.client.server.zookeeper;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.test.TestingServer;
+import org.apache.shenyu.common.dto.MetaData;
+import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ZookeeperClientTest {
+
+    private ZookeeperClient client;
+
+    private TestingServer server;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        this.server = new TestingServer();
+        ZookeeperConfig config = new ZookeeperConfig(server.getConnectString());
+        client = new ZookeeperClient(config);
+        client.start();
+    }
+
+    @AfterEach
+    public void cleanup() throws IOException {
+        client.close();
+        this.server.close();
+    }
+
+    @Test
+    void getClient() {
+        CuratorFramework curatorFramework = client.getClient();
+        assertNotNull(curatorFramework);
+    }
+
+    @Test
+    void isExist() {
+        boolean exist = client.isExist("/test");
+        assertFalse(exist);
+
+        client.createOrUpdate("/test", "", CreateMode.PERSISTENT);
+        exist = client.isExist("/test");
+        assertTrue(exist);
+    }
+
+    @Test
+    void getDirectly() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.getDirectly("/test");
+        assertEquals("hello", val);
+    }
+
+    @Test
+    void get() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals("hello", val);
+    }
+
+    @Test
+    void createOrUpdate() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals("hello", val);
+    }
+
+    @Test
+    void testCreateOrUpdate() {
+        MetaData data = new MetaData();
+        data.setAppName("test");
+        client.createOrUpdate("/test", data, CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals(GsonUtils.getInstance().toJson(data), val);
+    }
+
+    @Test
+    void delete() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals("hello", val);
+
+        client.delete("/test");
+        boolean exist = client.isExist("/test");
+        assertFalse(exist);
+    }
+
+    @Test
+    void getChildren() {
+        client.createOrUpdate("/test/1", "hello", CreateMode.PERSISTENT);
+        client.createOrUpdate("/test/2", "hello", CreateMode.PERSISTENT);
+
+        List<String> children = client.getChildren("/test");
+        assertTrue(children.contains("1"));
+        assertTrue(children.contains("2"));
+        assertEquals(2, children.size());
+    }
+
+    @Test
+    void getCache() {
+        CuratorCache cache = client.getCache("/test");
+        assertNull(cache);
+
+        client.addCache("/test");
+        cache = client.getCache("/test");
+        assertNotNull(cache);
+    }
+
+    @Test
+    void addCache() {
+        client.addCache("/test");
+        CuratorCache cache = client.getCache("/test");
+        assertNotNull(cache);
+    }
+}

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/test/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperClientTest.java
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/test/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperClientTest.java
@@ -19,21 +19,16 @@ package org.apache.shenyu.register.client.server.zookeeper;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.CuratorCache;
-import org.apache.curator.framework.recipes.cache.CuratorCacheBuilder;
 import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
-import org.apache.curator.framework.recipes.cache.CuratorCacheListenerBuilder;
 import org.apache.curator.test.TestingServer;
 import org.apache.shenyu.common.dto.MetaData;
 import org.apache.shenyu.common.utils.GsonUtils;
-import org.apache.shenyu.common.utils.PathMatchUtils;
-import org.apache.shenyu.register.common.path.RegisterPathConstants;
 import org.apache.zookeeper.CreateMode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/test/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperServerRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/test/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperServerRegisterRepositoryTest.java
@@ -17,31 +17,26 @@
 
 package org.apache.shenyu.register.client.server.zookeeper;
 
-import org.I0Itec.zkclient.IZkChildListener;
-import org.I0Itec.zkclient.IZkDataListener;
-import org.I0Itec.zkclient.ZkClient;
+import org.apache.curator.test.TestingServer;
+import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
 import org.apache.shenyu.common.utils.GsonUtils;
-import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
-import org.apache.shenyu.register.common.type.DataTypeParent;
 import org.apache.shenyu.register.client.server.api.ShenyuClientServerRegisterPublisher;
+import org.apache.shenyu.register.common.config.ShenyuRegisterCenterConfig;
+import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
+import org.apache.shenyu.register.common.dto.URIRegisterDTO;
+import org.apache.shenyu.register.common.type.DataTypeParent;
+import org.apache.zookeeper.CreateMode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Test for Zookeeper register center.
@@ -52,25 +47,24 @@ public class ZookeeperServerRegisterRepositoryTest {
     
     private ShenyuClientServerRegisterPublisher publisher;
     
-    private IZkChildListener zkChildListener;
-    
-    private IZkDataListener zkDataListener;
-    
+    private ZookeeperClient client;
+
     @BeforeEach
-    public void setUp() throws NoSuchFieldException, IllegalAccessException {
+    public void setUp() throws Exception {
         this.publisher = mockPublish();
+
+        TestingServer server = new TestingServer();
+        ShenyuRegisterCenterConfig config = new ShenyuRegisterCenterConfig();
+        config.setServerLists(server.getConnectString());
         this.repository = new ZookeeperClientServerRegisterRepository();
+        this.repository.init(publisher, config);
+
         Class<? extends ZookeeperClientServerRegisterRepository> clazz = this.repository.getClass();
-        
-        String fieldClientString = "zkClient";
-        Field fieldClient = clazz.getDeclaredField(fieldClientString);
-        fieldClient.setAccessible(true);
-        fieldClient.set(repository, mockZkClient());
-        
-        String fieldPublisherString = "publisher";
-        Field fieldPublisher = clazz.getDeclaredField(fieldPublisherString);
-        fieldPublisher.setAccessible(true);
-        fieldPublisher.set(repository, publisher);
+
+        String fieldString = "client";
+        Field field = clazz.getDeclaredField(fieldString);
+        field.setAccessible(true);
+        this.client = (ZookeeperClient) field.get(repository);
     }
     
     private ShenyuClientServerRegisterPublisher mockPublish() {
@@ -78,62 +72,48 @@ public class ZookeeperServerRegisterRepositoryTest {
         doNothing().when(publisher).publish(localAny());
         return publisher;
     }
-    
-    private ZkClient mockZkClient() {
-        MetaDataRegisterDTO data = MetaDataRegisterDTO.builder().build();
-        ZkClient client = mock(ZkClient.class);
-        
-        when(client.getChildren(anyString())).thenReturn(Arrays.asList("/path1", "/path2"));
-        when(client.readData(anyString())).thenReturn(GsonUtils.getInstance().toJson(data));
-        
-        doNothing().when(client).createPersistent(anyString(), anyBoolean());
-        
-        doAnswer(invocationOnMock -> {
-            this.zkChildListener = invocationOnMock.getArgument(1);
-            return null;
-        }).when(client).subscribeChildChanges(anyString(), any(IZkChildListener.class));
-        
-        doAnswer(invocationOnMock -> {
-            this.zkDataListener = invocationOnMock.getArgument(1);
-            return null;
-        }).when(client).subscribeDataChanges(anyString(), any(IZkDataListener.class));
-        
-        return client;
-    }
-    
+
     @Test
-    public void testSubscribeMetaData() throws Exception {
-        Class<? extends ZookeeperClientServerRegisterRepository> clazz = this.repository.getClass();
-        String methodString = "subscribeMetaData";
-        Method method = clazz.getDeclaredMethod(methodString, String.class);
-        method.setAccessible(true);
-        method.invoke(repository, "http");
-        
-        verify(publisher, times(4)).publish(localAny());
-        
-        zkChildListener.handleChildChange("/path", Arrays.asList("/path1", "/path2", "/path3"));
-        verify(publisher, times(10)).publish(localAny());
-        
-        String data = GsonUtils.getInstance().toJson(MetaDataRegisterDTO.builder().build());
-        zkDataListener.handleDataChange("/path1", data);
-        verify(publisher, times(11)).publish(localAny());
+    public void testSubscribeMetaData() throws InterruptedException {
+        MetaDataRegisterDTO data = MetaDataRegisterDTO.builder()
+                .rpcType("http")
+                .host("host")
+                .port(80)
+                .contextPath("/context")
+                .ruleName("ruleName")
+                .build();
+        String metadataPath = "/shenyu/register/metadata/http/context/context-ruleName";
+        client.createOrUpdate(metadataPath, GsonUtils.getInstance().toJson(data), CreateMode.PERSISTENT);
+
+        // wait 1ms for listener being invoked.
+        Thread.sleep(1000);
+
+        verify(publisher, times(1)).publish(localAny());
+        repository.close();
     }
     
     @Test
     public void testSubscribeURI() throws Exception {
-        Class<? extends ZookeeperClientServerRegisterRepository> clazz = this.repository.getClass();
-        String methodString = "subscribeURI";
-        Method method = clazz.getDeclaredMethod(methodString, String.class);
-        method.setAccessible(true);
-        method.invoke(repository, "http");
-        
+        URIRegisterDTO data = URIRegisterDTO.builder()
+                .rpcType("http")
+                .host("host")
+                .port(80)
+                .appName("/context")
+                .build();
+        String uriPath = "/shenyu/register/uri/http/context/host:80";
+        client.createOrUpdate(uriPath, GsonUtils.getInstance().toJson(data), CreateMode.EPHEMERAL);
+
+        // wait 1ms for listener being invoked.
+        Thread.sleep(1000);
+
+        verify(publisher, times(1)).publish(localAny());
+
+        client.delete(uriPath);
+
+        // wait 1ms for listener being invoked.
+        Thread.sleep(1000);
+
         verify(publisher, times(2)).publish(localAny());
-        
-        zkChildListener.handleChildChange("/path", Arrays.asList("/path1", "/path2", "/path3"));
-        verify(publisher, times(5)).publish(localAny());
-        
-        zkChildListener.handleChildChange("/path", Collections.emptyList());
-        verify(publisher, times(6)).publish(localAny());
     }
     
     private List<DataTypeParent> localAny() {

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/test/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperServerRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/src/test/java/org/apache/shenyu/register/client/server/zookeeper/ZookeeperServerRegisterRepositoryTest.java
@@ -18,7 +18,6 @@
 package org.apache.shenyu.register.client.server.zookeeper;
 
 import org.apache.curator.test.TestingServer;
-import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
 import org.apache.shenyu.common.utils.GsonUtils;
 import org.apache.shenyu.register.client.server.api.ShenyuClientServerRegisterPublisher;
 import org.apache.shenyu.register.common.config.ShenyuRegisterCenterConfig;

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
@@ -36,20 +36,20 @@
             <artifactId>shenyu-register-client-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.101tec</groupId>-->
+<!--            <artifactId>zkclient</artifactId>-->
+<!--            <exclusions>-->
+<!--                <exclusion>-->
+<!--                    <groupId>org.slf4j</groupId>-->
+<!--                    <artifactId>slf4j-log4j12</artifactId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <groupId>log4j</groupId>-->
+<!--                    <artifactId>log4j</artifactId>-->
+<!--                </exclusion>-->
+<!--            </exclusions>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
@@ -36,25 +36,5 @@
             <artifactId>shenyu-register-client-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>com.101tec</groupId>-->
-<!--            <artifactId>zkclient</artifactId>-->
-<!--            <exclusions>-->
-<!--                <exclusion>-->
-<!--                    <groupId>org.slf4j</groupId>-->
-<!--                    <artifactId>slf4j-log4j12</artifactId>-->
-<!--                </exclusion>-->
-<!--                <exclusion>-->
-<!--                    <groupId>log4j</groupId>-->
-<!--                    <artifactId>log4j</artifactId>-->
-<!--                </exclusion>-->
-<!--            </exclusions>-->
-<!--        </dependency>-->
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-test</artifactId>
-            <version>${curator-test.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
@@ -41,5 +41,13 @@
             <artifactId>curator-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
@@ -36,5 +36,10 @@
             <artifactId>shenyu-register-client-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClient.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClient.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.register.client.zookeeper;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.shenyu.common.exception.ShenyuException;
+import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.zookeeper.CreateMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ZookeeperClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperClient.class);
+
+    private final ZookeeperConfig config;
+
+    private final CuratorFramework client;
+
+    private final Map<String, CuratorCache> caches = new ConcurrentHashMap<>();
+
+    public ZookeeperClient(final ZookeeperConfig zookeeperConfig) {
+        this.config = zookeeperConfig;
+        ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(config.getBaseSleepTimeMilliseconds(), config.getMaxRetries(), config.getMaxSleepTimeMilliseconds());
+
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
+                .connectString(config.getServerLists())
+                .retryPolicy(retryPolicy)
+                .connectionTimeoutMs(config.getConnectionTimeoutMilliseconds())
+                .sessionTimeoutMs(config.getSessionTimeoutMilliseconds())
+                .namespace(config.getNamespace());
+
+        if (!StringUtils.isEmpty(config.getDigest())) {
+            builder.authorization("digest", config.getDigest().getBytes(StandardCharsets.UTF_8));
+        }
+
+        this.client = builder.build();
+    }
+
+    /**
+     * start.
+     */
+    public void start() {
+        this.client.start();
+        try {
+            this.client.blockUntilConnected();
+        } catch (InterruptedException e) {
+            LOGGER.warn("Interrupted during zookeeper client starting.");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * start.
+     */
+    public void close() {
+        // close all caches
+        for (Map.Entry<String, CuratorCache> cache : caches.entrySet()) {
+            CloseableUtils.closeQuietly(cache.getValue());
+        }
+        // close client
+        CloseableUtils.closeQuietly(client);
+    }
+
+    /**
+     * get curator framework.
+     *
+     * @return curator framework client.
+     */
+    public CuratorFramework getClient() {
+        return client;
+    }
+
+    /**
+     * check if key exist.
+     *
+     * @param key zookeeper path
+     * @return if exist.
+     */
+    public boolean isExist(final String key) {
+        try {
+            return null != client.checkExists().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get from zk directly.
+     *
+     * @param key zookeeper path
+     * @return value.
+     */
+    public String getDirectly(final String key) {
+        try {
+            byte[] ret = client.getData().forPath(key);
+            return Objects.isNull(ret) ? null : new String(ret, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get value for specific key.
+     *
+     * @param key zookeeper path
+     * @return value.
+     */
+    public String get(final String key) {
+        CuratorCache cache = findFromcache(key);
+        if (Objects.isNull(cache)) {
+            return getDirectly(key);
+        }
+        Optional<ChildData> data = cache.get(key);
+        return data.map(childData -> new String(childData.getData(), StandardCharsets.UTF_8)).orElseGet(() -> getDirectly(key));
+    }
+
+    /**
+     * create or update key with value.
+     *
+     * @param key   zookeeper path key.
+     * @param value string value.
+     * @param mode  creation mode.
+     */
+    public void createOrUpdate(final String key, final String value, final CreateMode mode) {
+        String val = StringUtils.isEmpty(value) ? "" : value;
+        try {
+            client.create().orSetData().creatingParentsIfNeeded().withMode(mode).forPath(key, val.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * create or update key with value.
+     *
+     * @param key   zookeeper path key.
+     * @param value object value.
+     * @param mode  creation mode.
+     */
+    public void createOrUpdate(final String key, final Object value, final CreateMode mode) {
+        if (value != null) {
+            String val = GsonUtils.getInstance().toJson(value);
+            createOrUpdate(key, val, mode);
+        } else {
+            createOrUpdate(key, "", mode);
+        }
+    }
+
+    /**
+     * delete a node with specific key.
+     *
+     * @param key zookeeper path key.
+     */
+    public void delete(final String key) {
+        try {
+            client.delete().deletingChildrenIfNeeded().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get children with specific key.
+     *
+     * @param key zookeeper key.
+     * @return children node name.
+     */
+    public List<String> getChildren(final String key) {
+        try {
+            return client.getChildren().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get created cache.
+     * @param path path.
+     * @return cache.
+     */
+    public CuratorCache getCache(final String path) {
+        return caches.get(path);
+    }
+
+    /**
+     * add new curator cache.
+     * @param path path.
+     * @param listeners listeners.
+     * @return cache.
+     */
+    public CuratorCache addCache(final String path, final CuratorCacheListener... listeners) {
+        CuratorCache cache = CuratorCache.build(client, path);
+        caches.put(path, cache);
+        if (listeners != null && listeners.length > 0) {
+            for (CuratorCacheListener listener : listeners) {
+                cache.listenable().addListener(listener);
+            }
+        }
+        cache.start();
+        return cache;
+    }
+
+    /**
+     * find cache with  key.
+     * @param key key.
+     * @return cache.
+     */
+    private CuratorCache findFromcache(final String key) {
+        for (Map.Entry<String, CuratorCache> cache : caches.entrySet()) {
+            if (key.startsWith(cache.getKey())) {
+                return cache.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepository.java
@@ -19,8 +19,6 @@ package org.apache.shenyu.register.client.zookeeper;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.framework.state.ConnectionState;
-import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
-import org.apache.shenyu.common.client.zookeeper.ZookeeperConfig;
 import org.apache.shenyu.common.constant.Constants;
 import org.apache.shenyu.common.constant.DefaultPathConstants;
 import org.apache.shenyu.common.enums.RpcTypeEnum;

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepository.java
@@ -36,7 +36,11 @@ import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
 import static org.apache.shenyu.common.constant.Constants.PATH_SEPARATOR;
 

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepository.java
@@ -129,6 +129,7 @@ public class ZookeeperClientRegisterRepository implements ShenyuClientRegisterRe
         String metadataNodeName = buildMetadataNodeName(metadata);
         String metaDataPath = RegisterPathConstants.buildMetaDataParentPath(rpcType, contextPath);
         String realNode = RegisterPathConstants.buildRealNode(metaDataPath, metadataNodeName);
+        // avoid dup registration for metadata
         synchronized (metadataSet) {
             if (metadataSet.contains(realNode)) {
                 return;

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepository.java
@@ -17,13 +17,11 @@
 
 package org.apache.shenyu.register.client.zookeeper;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import org.I0Itec.zkclient.IZkStateListener;
-import org.I0Itec.zkclient.ZkClient;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
+import org.apache.shenyu.common.client.zookeeper.ZookeeperConfig;
 import org.apache.shenyu.common.constant.Constants;
-import static org.apache.shenyu.common.constant.Constants.PATH_SEPARATOR;
 import org.apache.shenyu.common.constant.DefaultPathConstants;
 import org.apache.shenyu.common.enums.RpcTypeEnum;
 import org.apache.shenyu.common.utils.ContextPathUtils;
@@ -34,9 +32,13 @@ import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
 import org.apache.shenyu.register.common.dto.URIRegisterDTO;
 import org.apache.shenyu.register.common.path.RegisterPathConstants;
 import org.apache.shenyu.spi.Join;
-import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static org.apache.shenyu.common.constant.Constants.PATH_SEPARATOR;
 
 /**
  * The type Zookeeper client register repository.
@@ -46,11 +48,14 @@ public class ZookeeperClientRegisterRepository implements ShenyuClientRegisterRe
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperClientRegisterRepository.class);
 
-    private ZkClient zkClient;
+    private ZookeeperClient client;
 
     private final Map<String, String> nodeDataMap = new HashMap<>();
 
-    public ZookeeperClientRegisterRepository() { }
+    private final Set<String> metadataSet = new HashSet<>();
+
+    public ZookeeperClientRegisterRepository() {
+    }
 
     public ZookeeperClientRegisterRepository(final ShenyuRegisterCenterConfig config) {
         init(config);
@@ -61,8 +66,36 @@ public class ZookeeperClientRegisterRepository implements ShenyuClientRegisterRe
         Properties props = config.getProps();
         int sessionTimeout = Integer.parseInt(props.getProperty("sessionTimeout", "3000"));
         int connectionTimeout = Integer.parseInt(props.getProperty("connectionTimeout", "3000"));
-        this.zkClient = new ZkClient(config.getServerLists(), sessionTimeout, connectionTimeout);
-        this.zkClient.subscribeStateChanges(new ZkStateListener());
+
+        int baseSleepTime = Integer.parseInt(props.getProperty("baseSleepTime", "1000"));
+        int maxRetries = Integer.parseInt(props.getProperty("maxRetries", "3"));
+        int maxSleepTime = Integer.parseInt(props.getProperty("maxSleepTime", String.valueOf(Integer.MAX_VALUE)));
+
+        ZookeeperConfig zkConfig = new ZookeeperConfig(config.getServerLists());
+        zkConfig.setBaseSleepTimeMilliseconds(baseSleepTime)
+                .setMaxRetries(maxRetries)
+                .setMaxSleepTimeMilliseconds(maxSleepTime)
+                .setSessionTimeoutMilliseconds(sessionTimeout)
+                .setConnectionTimeoutMilliseconds(connectionTimeout);
+
+        String digest = props.getProperty("digest");
+        if (!StringUtils.isEmpty(digest)) {
+            zkConfig.setDigest(digest);
+        }
+
+        this.client = new ZookeeperClient(zkConfig);
+        this.client.getClient().getConnectionStateListenable().addListener((c, newState) -> {
+            if (newState == ConnectionState.RECONNECTED) {
+                nodeDataMap.forEach((k, v) -> {
+                    if (!client.isExist(k)) {
+                        client.createOrUpdate(k, v, CreateMode.EPHEMERAL);
+                        LOGGER.info("zookeeper client register uri success: {}", v);
+                    }
+                });
+            }
+        });
+
+        client.start();
     }
 
     @Override
@@ -70,9 +103,8 @@ public class ZookeeperClientRegisterRepository implements ShenyuClientRegisterRe
         String rpcType = metadata.getRpcType();
         String contextPath = ContextPathUtils.buildRealNode(metadata.getContextPath(), metadata.getAppName());
         registerMetadata(rpcType, contextPath, metadata);
-        LOGGER.info("{} zookeeper client register success: {}", rpcType, metadata);
     }
-    
+
     /**
      * Persist uri.
      *
@@ -83,11 +115,12 @@ public class ZookeeperClientRegisterRepository implements ShenyuClientRegisterRe
         String rpcType = registerDTO.getRpcType();
         String contextPath = ContextPathUtils.buildRealNode(registerDTO.getContextPath(), registerDTO.getAppName());
         registerURI(rpcType, contextPath, registerDTO);
+        LOGGER.info("{} zookeeper client register uri success: {}", rpcType, registerDTO);
     }
-    
+
     @Override
     public void close() {
-        zkClient.close();
+        this.client.close();
     }
 
     private void registerMetadata(final String rpcType,
@@ -95,31 +128,24 @@ public class ZookeeperClientRegisterRepository implements ShenyuClientRegisterRe
                                   final MetaDataRegisterDTO metadata) {
         String metadataNodeName = buildMetadataNodeName(metadata);
         String metaDataPath = RegisterPathConstants.buildMetaDataParentPath(rpcType, contextPath);
-        if (!zkClient.exists(metaDataPath)) {
-            zkClient.createPersistent(metaDataPath, true);
-        }
         String realNode = RegisterPathConstants.buildRealNode(metaDataPath, metadataNodeName);
-        if (zkClient.exists(realNode)) {
-            zkClient.writeData(realNode, GsonUtils.getInstance().toJson(metadata));
-        } else {
-            // if contextPath has two /, in zk means two folder, we need to create parent folder first, or else it will throw no node exception
-            zkClient.createPersistent(realNode, true);
-            zkClient.writeData(realNode, GsonUtils.getInstance().toJson(metadata));
+        synchronized (metadataSet) {
+            if (metadataSet.contains(realNode)) {
+                return;
+            }
+            metadataSet.add(realNode);
         }
+        client.createOrUpdate(realNode, metadata, CreateMode.PERSISTENT);
+        LOGGER.info("{} zookeeper client register metadata success: {}", rpcType, metadata);
     }
-    
+
     private synchronized void registerURI(final String rpcType, final String contextPath, final URIRegisterDTO registerDTO) {
         String uriNodeName = buildURINodeName(registerDTO);
         String uriPath = RegisterPathConstants.buildURIParentPath(rpcType, contextPath);
-        if (!zkClient.exists(uriPath)) {
-            zkClient.createPersistent(uriPath, true);
-        }
         String realNode = RegisterPathConstants.buildRealNode(uriPath, uriNodeName);
-        if (!zkClient.exists(realNode)) {
-            String nodeData = GsonUtils.getInstance().toJson(registerDTO);
-            nodeDataMap.put(realNode, nodeData);
-            zkClient.createEphemeral(realNode, nodeData);
-        }
+        String nodeData = GsonUtils.getInstance().toJson(registerDTO);
+        nodeDataMap.put(realNode, nodeData);
+        client.createOrUpdate(realNode, nodeData, CreateMode.EPHEMERAL);
     }
 
     private String buildURINodeName(final URIRegisterDTO registerDTO) {
@@ -140,27 +166,5 @@ public class ZookeeperClientRegisterRepository implements ShenyuClientRegisterRe
             nodeName = RegisterPathConstants.buildNodeName(metadata.getServiceName(), metadata.getMethodName());
         }
         return nodeName.startsWith(PATH_SEPARATOR) ? nodeName.substring(1) : nodeName;
-    }
-
-    private class ZkStateListener implements IZkStateListener {
-        @Override
-        public void handleStateChanged(final Watcher.Event.KeeperState keeperState) {
-            if (Watcher.Event.KeeperState.SyncConnected.equals(keeperState)) {
-                nodeDataMap.forEach((k, v) -> {
-                    if (!zkClient.exists(k)) {
-                        zkClient.createEphemeral(k, v);
-                        LOGGER.info("zookeeper client register success: {}", v);
-                    }
-                });
-            }
-        }
-
-        @Override
-        public void handleNewSession() {
-        }
-
-        @Override
-        public void handleSessionEstablishmentError(final Throwable throwable) {
-        }
     }
 }

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperConfig.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperConfig.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.register.client.zookeeper;
+
+public class ZookeeperConfig {
+    /**
+     * zookeeper server list.
+     * e.g. host1:2181,host2:2181
+     */
+    private final String serverLists;
+
+    /**
+     * zookeeper namespace.
+     */
+    private String namespace = "";
+
+    /**
+     * initial amount of time to wait between retries.
+     */
+    private int baseSleepTimeMilliseconds = 1000;
+
+    /**
+     * max time in ms to sleep on each retry.
+     */
+    private int maxSleepTimeMilliseconds = Integer.MAX_VALUE;
+
+    /**
+     * max number of times to retry.
+     */
+    private int maxRetries = 3;
+
+    /**
+     * session timeout.
+     */
+    private int sessionTimeoutMilliseconds = 60 * 1000;
+
+    /**
+     * connection timeout.
+     */
+    private int connectionTimeoutMilliseconds = 15 * 1000;
+
+    /**
+     * auth token digest. no auth by default.
+     */
+    private String digest;
+
+    public ZookeeperConfig(final String serverLists) {
+        this.serverLists = serverLists;
+    }
+
+    /**
+     * get zookeeper server list.
+     * @return server list.
+     */
+    public String getServerLists() {
+        return serverLists;
+    }
+
+    /**
+     * set namespace.
+     * @param namespace zk namespace
+     * @return zk config
+     */
+    public ZookeeperConfig setNamespace(final String namespace) {
+        this.namespace = namespace;
+        return this;
+    }
+
+    /**
+     * get namespace.
+     * @return namespace
+     */
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * get base sleep time.
+     * @return base sleep time.
+     */
+    public int getBaseSleepTimeMilliseconds() {
+        return baseSleepTimeMilliseconds;
+    }
+
+    /**
+     * set base sleep time.
+     * @param baseSleepTimeMilliseconds base sleep time in milliseconds.
+     * @return zk config.
+     */
+    public ZookeeperConfig setBaseSleepTimeMilliseconds(final int baseSleepTimeMilliseconds) {
+        this.baseSleepTimeMilliseconds = baseSleepTimeMilliseconds;
+        return this;
+    }
+
+    /**
+     * get max sleep time.
+     * @return max sleep time
+     */
+    public int getMaxSleepTimeMilliseconds() {
+        return maxSleepTimeMilliseconds;
+    }
+
+    /**
+     * set max sleep time.
+     * @param maxSleepTimeMilliseconds max sleep time.
+     * @return zk config.
+     */
+    public ZookeeperConfig setMaxSleepTimeMilliseconds(final int maxSleepTimeMilliseconds) {
+        this.maxSleepTimeMilliseconds = maxSleepTimeMilliseconds;
+        return this;
+    }
+
+    /**
+     * get max retries.
+     * @return max retries
+     */
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    /**
+     * set max retries count.
+     * @param maxRetries max retries
+     * @return zk config.
+     */
+    public ZookeeperConfig setMaxRetries(final int maxRetries) {
+        this.maxRetries = maxRetries;
+        return this;
+    }
+
+    /**
+     * get session timeout in milliseconds.
+     * @return session timeout.
+     */
+    public int getSessionTimeoutMilliseconds() {
+        return sessionTimeoutMilliseconds;
+    }
+
+    /**
+     * set session timeout in milliseconds.
+     * @param sessionTimeoutMilliseconds session timeout
+     * @return zk config.
+     */
+    public ZookeeperConfig setSessionTimeoutMilliseconds(final int sessionTimeoutMilliseconds) {
+        this.sessionTimeoutMilliseconds = sessionTimeoutMilliseconds;
+        return this;
+    }
+
+    /**
+     * get connection timeout in milliseconds.
+     * @return connection timeout.
+     */
+    public int getConnectionTimeoutMilliseconds() {
+        return connectionTimeoutMilliseconds;
+    }
+
+    /**
+     * set connection timeout in milliseconds.
+     * @param connectionTimeoutMilliseconds connection timeout.
+     * @return zk config.
+     */
+    public ZookeeperConfig setConnectionTimeoutMilliseconds(final int connectionTimeoutMilliseconds) {
+        this.connectionTimeoutMilliseconds = connectionTimeoutMilliseconds;
+        return this;
+    }
+
+    /**
+     * get digest.
+     * @return digest.
+     */
+    public String getDigest() {
+        return digest;
+    }
+
+    /**
+     * set digest.
+     * @param digest digest
+     * @return zk config.
+     */
+    public ZookeeperConfig setDigest(final String digest) {
+        this.digest = digest;
+        return this;
+    }
+}

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepositoryTest.java
@@ -18,7 +18,6 @@
 package org.apache.shenyu.register.client.zookeeper;
 
 import org.apache.curator.test.TestingServer;
-import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
 import org.apache.shenyu.common.enums.RpcTypeEnum;
 import org.apache.shenyu.common.utils.GsonUtils;
 import org.apache.shenyu.register.common.config.ShenyuRegisterCenterConfig;

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepositoryTest.java
@@ -48,7 +48,6 @@ public class ZookeeperClientRegisterRepositoryTest {
         config.setServerLists(server.getConnectString());
         this.repository.init(config);
 
-
         Class<? extends ZookeeperClientRegisterRepository> clazz = this.repository.getClass();
 
         String fieldString = "client";

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepositoryTest.java
@@ -1,154 +1,108 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//
-//package org.apache.shenyu.register.client.zookeeper;
-//
-//import org.apache.shenyu.common.enums.RpcTypeEnum;
-//import org.apache.shenyu.common.utils.GsonUtils;
-//import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
-//import org.apache.shenyu.register.common.dto.URIRegisterDTO;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//
-//import java.lang.reflect.Field;
-//import java.util.HashMap;
-//import java.util.HashSet;
-//import java.util.Map;
-//import java.util.Set;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.Mockito.doAnswer;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.when;
-//
-///**
-// * Test for Zookeeper client register repository.
-// */
-//public class ZookeeperClientRegisterRepositoryTest {
-//
-//    private ZookeeperClientRegisterRepository repository;
-//
-//    private final Map<String, Object> zookeeperBroker = new HashMap<>();
-//
-//    private final Set<String> ephemeralNode = new HashSet<>();
-//
-//    @BeforeEach
-//    public void setUp() throws NoSuchFieldException, IllegalAccessException {
-//        this.repository = new ZookeeperClientRegisterRepository();
-//        Class<? extends ZookeeperClientRegisterRepository> clazz = this.repository.getClass();
-//
-//        String fieldString = "zkClient";
-//        Field field = clazz.getDeclaredField(fieldString);
-//        field.setAccessible(true);
-//        field.set(repository, mockZkClient());
-//
-//        zookeeperBroker.clear();
-//        ephemeralNode.clear();
-//    }
-//
-//    private ZkClient mockZkClient() {
-//        ZkClient zkClient = mock(ZkClient.class);
-//
-//        doAnswer(invocationOnMock -> {
-//            String key = invocationOnMock.getArgument(0);
-//            String value = invocationOnMock.getArgument(1);
-//            zookeeperBroker.put(key, value);
-//            ephemeralNode.add(key);
-//            return true;
-//        }).when(zkClient).createEphemeral(anyString(), any(Object.class));
-//
-//        doAnswer(invocationOnMock -> {
-//            String key = invocationOnMock.getArgument(0);
-//            String value = invocationOnMock.getArgument(1);
-//            zookeeperBroker.put(key, value);
-//            return true;
-//        }).when(zkClient).createPersistent(any(), any());
-//
-//        doAnswer(invocationOnMock -> {
-//            String key = invocationOnMock.getArgument(0);
-//            String value = invocationOnMock.getArgument(1);
-//            zookeeperBroker.put(key, value);
-//            return true;
-//        }).when(zkClient).writeData(any(), any());
-//
-//        doAnswer(invocationOnMock -> {
-//            String node = invocationOnMock.getArgument(0);
-//            return zookeeperBroker.containsKey(node);
-//        }).when(zkClient).exists(anyString());
-//
-//        doAnswer(invocationOnMock -> {
-//            ephemeralNode.forEach(zookeeperBroker::remove);
-//            return true;
-//        }).when(zkClient).close();
-//
-//        return zkClient;
-//    }
-//
-//    @Test
-//    public void testPersistInterface() {
-//        MetaDataRegisterDTO data = MetaDataRegisterDTO.builder()
-//                .rpcType("http")
-//                .host("host")
-//                .port(80)
-//                .contextPath("/context")
-//                .ruleName("ruleName")
-//                .build();
-//        repository.persistInterface(data);
-//        String metadataPath = "/shenyu/register/metadata/http/context/context-ruleName";
-//        assertTrue(zookeeperBroker.containsKey(metadataPath));
-//        assertEquals(zookeeperBroker.get(metadataPath), GsonUtils.getInstance().toJson(data));
-//        repository.close();
-//    }
-//
-//    @Test
-//    public void testPersistUri() {
-//        URIRegisterDTO data = URIRegisterDTO.builder()
-//                .rpcType("http")
-//                .host("host")
-//                .port(80)
-//                .appName("/context")
-//                .build();
-//        repository.persistURI(data);
-//        String uriPath = "/shenyu/register/uri/http/context/host:80";
-//        assertTrue(zookeeperBroker.containsKey(uriPath));
-//        assertEquals(zookeeperBroker.get(uriPath), GsonUtils.getInstance().toJson(data));
-//        repository.close();
-//    }
-//
-//    @Test
-//    public void testPersistInterfaceDoAnswerWriteData4Grpc() {
-//        ZkClient zkClient = mock(ZkClient.class);
-//        when(zkClient.exists(anyString())).thenReturn(true);
-//        final MetaDataRegisterDTO data = MetaDataRegisterDTO.builder()
-//                .rpcType(RpcTypeEnum.GRPC.getName())
-//                .host("host")
-//                .port(80)
-//                .contextPath("/context")
-//                .ruleName("ruleName")
-//                .serviceName("testService")
-//                .methodName("testMethod")
-//                .build();
-//        repository.persistInterface(data);
-//        String metadataPath = "/shenyu/register/metadata/grpc/context/testService.testMethod";
-//        assertTrue(zookeeperBroker.containsKey(metadataPath));
-//        assertEquals(zookeeperBroker.get(metadataPath), GsonUtils.getInstance().toJson(data));
-//        repository.close();
-//    }
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.register.client.zookeeper;
+
+import org.apache.curator.test.TestingServer;
+import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
+import org.apache.shenyu.common.enums.RpcTypeEnum;
+import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.shenyu.register.common.config.ShenyuRegisterCenterConfig;
+import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
+import org.apache.shenyu.register.common.dto.URIRegisterDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test for Zookeeper client register repository.
+ */
+public class ZookeeperClientRegisterRepositoryTest {
+
+    private ZookeeperClientRegisterRepository repository;
+
+    private ZookeeperClient client;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        TestingServer server = new TestingServer();
+        this.repository = new ZookeeperClientRegisterRepository();
+        ShenyuRegisterCenterConfig config = new ShenyuRegisterCenterConfig();
+        config.setServerLists(server.getConnectString());
+        this.repository.init(config);
+
+
+        Class<? extends ZookeeperClientRegisterRepository> clazz = this.repository.getClass();
+
+        String fieldString = "client";
+        Field field = clazz.getDeclaredField(fieldString);
+        field.setAccessible(true);
+        this.client = (ZookeeperClient) field.get(repository);
+    }
+
+    @Test
+    public void testPersistInterface() {
+        MetaDataRegisterDTO data = MetaDataRegisterDTO.builder()
+                .rpcType("http")
+                .host("host")
+                .port(80)
+                .contextPath("/context")
+                .ruleName("ruleName")
+                .build();
+        repository.persistInterface(data);
+        String metadataPath = "/shenyu/register/metadata/http/context/context-ruleName";
+        String value = client.get(metadataPath);
+        assertEquals(value, GsonUtils.getInstance().toJson(data));
+        repository.close();
+    }
+
+    @Test
+    public void testPersistUri() {
+        URIRegisterDTO data = URIRegisterDTO.builder()
+                .rpcType("http")
+                .host("host")
+                .port(80)
+                .appName("/context")
+                .build();
+        repository.persistURI(data);
+        String uriPath = "/shenyu/register/uri/http/context/host:80";
+        String value = client.get(uriPath);
+        assertEquals(value, GsonUtils.getInstance().toJson(data));
+        repository.close();
+    }
+
+    @Test
+    public void testPersistInterfaceDoAnswerWriteData4Grpc() {
+        final MetaDataRegisterDTO data = MetaDataRegisterDTO.builder()
+                .rpcType(RpcTypeEnum.GRPC.getName())
+                .host("host")
+                .port(80)
+                .contextPath("/context")
+                .ruleName("ruleName")
+                .serviceName("testService")
+                .methodName("testMethod")
+                .build();
+        repository.persistInterface(data);
+        String metadataPath = "/shenyu/register/metadata/grpc/context/testService.testMethod";
+        String value = client.get(metadataPath);
+        assertEquals(value, GsonUtils.getInstance().toJson(data));
+        repository.close();
+    }
+}

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepositoryTest.java
@@ -1,155 +1,154 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package org.apache.shenyu.register.client.zookeeper;
-
-import org.I0Itec.zkclient.ZkClient;
-import org.apache.shenyu.common.enums.RpcTypeEnum;
-import org.apache.shenyu.common.utils.GsonUtils;
-import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
-import org.apache.shenyu.register.common.dto.URIRegisterDTO;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-/**
- * Test for Zookeeper client register repository.
- */
-public class ZookeeperClientRegisterRepositoryTest {
-
-    private ZookeeperClientRegisterRepository repository;
-
-    private final Map<String, Object> zookeeperBroker = new HashMap<>();
-
-    private final Set<String> ephemeralNode = new HashSet<>();
-
-    @BeforeEach
-    public void setUp() throws NoSuchFieldException, IllegalAccessException {
-        this.repository = new ZookeeperClientRegisterRepository();
-        Class<? extends ZookeeperClientRegisterRepository> clazz = this.repository.getClass();
-
-        String fieldString = "zkClient";
-        Field field = clazz.getDeclaredField(fieldString);
-        field.setAccessible(true);
-        field.set(repository, mockZkClient());
-
-        zookeeperBroker.clear();
-        ephemeralNode.clear();
-    }
-
-    private ZkClient mockZkClient() {
-        ZkClient zkClient = mock(ZkClient.class);
-
-        doAnswer(invocationOnMock -> {
-            String key = invocationOnMock.getArgument(0);
-            String value = invocationOnMock.getArgument(1);
-            zookeeperBroker.put(key, value);
-            ephemeralNode.add(key);
-            return true;
-        }).when(zkClient).createEphemeral(anyString(), any(Object.class));
-
-        doAnswer(invocationOnMock -> {
-            String key = invocationOnMock.getArgument(0);
-            String value = invocationOnMock.getArgument(1);
-            zookeeperBroker.put(key, value);
-            return true;
-        }).when(zkClient).createPersistent(any(), any());
-
-        doAnswer(invocationOnMock -> {
-            String key = invocationOnMock.getArgument(0);
-            String value = invocationOnMock.getArgument(1);
-            zookeeperBroker.put(key, value);
-            return true;
-        }).when(zkClient).writeData(any(), any());
-
-        doAnswer(invocationOnMock -> {
-            String node = invocationOnMock.getArgument(0);
-            return zookeeperBroker.containsKey(node);
-        }).when(zkClient).exists(anyString());
-
-        doAnswer(invocationOnMock -> {
-            ephemeralNode.forEach(zookeeperBroker::remove);
-            return true;
-        }).when(zkClient).close();
-
-        return zkClient;
-    }
-
-    @Test
-    public void testPersistInterface() {
-        MetaDataRegisterDTO data = MetaDataRegisterDTO.builder()
-                .rpcType("http")
-                .host("host")
-                .port(80)
-                .contextPath("/context")
-                .ruleName("ruleName")
-                .build();
-        repository.persistInterface(data);
-        String metadataPath = "/shenyu/register/metadata/http/context/context-ruleName";
-        assertTrue(zookeeperBroker.containsKey(metadataPath));
-        assertEquals(zookeeperBroker.get(metadataPath), GsonUtils.getInstance().toJson(data));
-        repository.close();
-    }
-    
-    @Test
-    public void testPersistUri() {
-        URIRegisterDTO data = URIRegisterDTO.builder()
-                .rpcType("http")
-                .host("host")
-                .port(80)
-                .appName("/context")
-                .build();
-        repository.persistURI(data);
-        String uriPath = "/shenyu/register/uri/http/context/host:80";
-        assertTrue(zookeeperBroker.containsKey(uriPath));
-        assertEquals(zookeeperBroker.get(uriPath), GsonUtils.getInstance().toJson(data));
-        repository.close();
-    }
-
-    @Test
-    public void testPersistInterfaceDoAnswerWriteData4Grpc() {
-        ZkClient zkClient = mock(ZkClient.class);
-        when(zkClient.exists(anyString())).thenReturn(true);
-        final MetaDataRegisterDTO data = MetaDataRegisterDTO.builder()
-                .rpcType(RpcTypeEnum.GRPC.getName())
-                .host("host")
-                .port(80)
-                .contextPath("/context")
-                .ruleName("ruleName")
-                .serviceName("testService")
-                .methodName("testMethod")
-                .build();
-        repository.persistInterface(data);
-        String metadataPath = "/shenyu/register/metadata/grpc/context/testService.testMethod";
-        assertTrue(zookeeperBroker.containsKey(metadataPath));
-        assertEquals(zookeeperBroker.get(metadataPath), GsonUtils.getInstance().toJson(data));
-        repository.close();
-    }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one or more
+// * contributor license agreements.  See the NOTICE file distributed with
+// * this work for additional information regarding copyright ownership.
+// * The ASF licenses this file to You under the Apache License, Version 2.0
+// * (the "License"); you may not use this file except in compliance with
+// * the License.  You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package org.apache.shenyu.register.client.zookeeper;
+//
+//import org.apache.shenyu.common.enums.RpcTypeEnum;
+//import org.apache.shenyu.common.utils.GsonUtils;
+//import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
+//import org.apache.shenyu.register.common.dto.URIRegisterDTO;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//
+//import java.lang.reflect.Field;
+//import java.util.HashMap;
+//import java.util.HashSet;
+//import java.util.Map;
+//import java.util.Set;
+//
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.Mockito.doAnswer;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.when;
+//
+///**
+// * Test for Zookeeper client register repository.
+// */
+//public class ZookeeperClientRegisterRepositoryTest {
+//
+//    private ZookeeperClientRegisterRepository repository;
+//
+//    private final Map<String, Object> zookeeperBroker = new HashMap<>();
+//
+//    private final Set<String> ephemeralNode = new HashSet<>();
+//
+//    @BeforeEach
+//    public void setUp() throws NoSuchFieldException, IllegalAccessException {
+//        this.repository = new ZookeeperClientRegisterRepository();
+//        Class<? extends ZookeeperClientRegisterRepository> clazz = this.repository.getClass();
+//
+//        String fieldString = "zkClient";
+//        Field field = clazz.getDeclaredField(fieldString);
+//        field.setAccessible(true);
+//        field.set(repository, mockZkClient());
+//
+//        zookeeperBroker.clear();
+//        ephemeralNode.clear();
+//    }
+//
+//    private ZkClient mockZkClient() {
+//        ZkClient zkClient = mock(ZkClient.class);
+//
+//        doAnswer(invocationOnMock -> {
+//            String key = invocationOnMock.getArgument(0);
+//            String value = invocationOnMock.getArgument(1);
+//            zookeeperBroker.put(key, value);
+//            ephemeralNode.add(key);
+//            return true;
+//        }).when(zkClient).createEphemeral(anyString(), any(Object.class));
+//
+//        doAnswer(invocationOnMock -> {
+//            String key = invocationOnMock.getArgument(0);
+//            String value = invocationOnMock.getArgument(1);
+//            zookeeperBroker.put(key, value);
+//            return true;
+//        }).when(zkClient).createPersistent(any(), any());
+//
+//        doAnswer(invocationOnMock -> {
+//            String key = invocationOnMock.getArgument(0);
+//            String value = invocationOnMock.getArgument(1);
+//            zookeeperBroker.put(key, value);
+//            return true;
+//        }).when(zkClient).writeData(any(), any());
+//
+//        doAnswer(invocationOnMock -> {
+//            String node = invocationOnMock.getArgument(0);
+//            return zookeeperBroker.containsKey(node);
+//        }).when(zkClient).exists(anyString());
+//
+//        doAnswer(invocationOnMock -> {
+//            ephemeralNode.forEach(zookeeperBroker::remove);
+//            return true;
+//        }).when(zkClient).close();
+//
+//        return zkClient;
+//    }
+//
+//    @Test
+//    public void testPersistInterface() {
+//        MetaDataRegisterDTO data = MetaDataRegisterDTO.builder()
+//                .rpcType("http")
+//                .host("host")
+//                .port(80)
+//                .contextPath("/context")
+//                .ruleName("ruleName")
+//                .build();
+//        repository.persistInterface(data);
+//        String metadataPath = "/shenyu/register/metadata/http/context/context-ruleName";
+//        assertTrue(zookeeperBroker.containsKey(metadataPath));
+//        assertEquals(zookeeperBroker.get(metadataPath), GsonUtils.getInstance().toJson(data));
+//        repository.close();
+//    }
+//
+//    @Test
+//    public void testPersistUri() {
+//        URIRegisterDTO data = URIRegisterDTO.builder()
+//                .rpcType("http")
+//                .host("host")
+//                .port(80)
+//                .appName("/context")
+//                .build();
+//        repository.persistURI(data);
+//        String uriPath = "/shenyu/register/uri/http/context/host:80";
+//        assertTrue(zookeeperBroker.containsKey(uriPath));
+//        assertEquals(zookeeperBroker.get(uriPath), GsonUtils.getInstance().toJson(data));
+//        repository.close();
+//    }
+//
+//    @Test
+//    public void testPersistInterfaceDoAnswerWriteData4Grpc() {
+//        ZkClient zkClient = mock(ZkClient.class);
+//        when(zkClient.exists(anyString())).thenReturn(true);
+//        final MetaDataRegisterDTO data = MetaDataRegisterDTO.builder()
+//                .rpcType(RpcTypeEnum.GRPC.getName())
+//                .host("host")
+//                .port(80)
+//                .contextPath("/context")
+//                .ruleName("ruleName")
+//                .serviceName("testService")
+//                .methodName("testMethod")
+//                .build();
+//        repository.persistInterface(data);
+//        String metadataPath = "/shenyu/register/metadata/grpc/context/testService.testMethod";
+//        assertTrue(zookeeperBroker.containsKey(metadataPath));
+//        assertEquals(zookeeperBroker.get(metadataPath), GsonUtils.getInstance().toJson(data));
+//        repository.close();
+//    }
+//}

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.register.client.zookeeper;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.test.TestingServer;
+import org.apache.shenyu.common.dto.MetaData;
+import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ZookeeperClientTest {
+
+    private ZookeeperClient client;
+
+    private TestingServer server;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        this.server = new TestingServer();
+        ZookeeperConfig config = new ZookeeperConfig(server.getConnectString());
+        client = new ZookeeperClient(config);
+        client.start();
+    }
+
+    @AfterEach
+    public void cleanup() throws IOException {
+        client.close();
+        this.server.close();
+    }
+
+    @Test
+    void getClient() {
+        CuratorFramework curatorFramework = client.getClient();
+        assertNotNull(curatorFramework);
+    }
+
+    @Test
+    void isExist() {
+        boolean exist = client.isExist("/test");
+        assertFalse(exist);
+
+        client.createOrUpdate("/test", "", CreateMode.PERSISTENT);
+        exist = client.isExist("/test");
+        assertTrue(exist);
+    }
+
+    @Test
+    void getDirectly() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.getDirectly("/test");
+        assertEquals("hello", val);
+    }
+
+    @Test
+    void get() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals("hello", val);
+    }
+
+    @Test
+    void createOrUpdate() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals("hello", val);
+    }
+
+    @Test
+    void testCreateOrUpdate() {
+        MetaData data = new MetaData();
+        data.setAppName("test");
+        client.createOrUpdate("/test", data, CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals(GsonUtils.getInstance().toJson(data), val);
+    }
+
+    @Test
+    void delete() {
+        client.createOrUpdate("/test", "hello", CreateMode.PERSISTENT);
+        String val = client.get("/test");
+        assertEquals("hello", val);
+
+        client.delete("/test");
+        boolean exist = client.isExist("/test");
+        assertFalse(exist);
+    }
+
+    @Test
+    void getChildren() {
+        client.createOrUpdate("/test/1", "hello", CreateMode.PERSISTENT);
+        client.createOrUpdate("/test/2", "hello", CreateMode.PERSISTENT);
+
+        List<String> children = client.getChildren("/test");
+        assertTrue(children.contains("1"));
+        assertTrue(children.contains("2"));
+        assertEquals(2, children.size());
+    }
+
+    @Test
+    void getCache() {
+        CuratorCache cache = client.getCache("/test");
+        assertNull(cache);
+
+        client.addCache("/test");
+        cache = client.getCache("/test");
+        assertNotNull(cache);
+    }
+
+    @Test
+    void addCache() {
+        client.addCache("/test");
+        CuratorCache cache = client.getCache("/test");
+        assertNotNull(cache);
+    }
+}

--- a/shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/path/RegisterPathConstants.java
+++ b/shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/path/RegisterPathConstants.java
@@ -36,7 +36,19 @@ public class RegisterPathConstants {
      * Dot separator.
      */
     private static final String DOT_SEPARATOR = ".";
-    
+
+    /**
+     * uri register path pattern.
+     * e.g. /shenyu/register/uri/{rpcType}/{context}/{urlInstance}
+     */
+    public static final String REGISTER_URI_INSTANCE_PATH = "/shenyu/register/uri/*/*/*";
+
+    /**
+     * metadata register path pattern.
+     * e.g. /shenyu/register/metadata/{rpcType}/{context}/{metadata}
+     */
+    public static final String REGISTER_METADATA_INSTANCE_PATH = "/shenyu/register/metadata/*/*/*";
+
     /**
      * build child path of "/shenyu/register/metadata/{rpcType}/".
      *

--- a/shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/path/RegisterPathConstants.java
+++ b/shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/path/RegisterPathConstants.java
@@ -21,7 +21,19 @@ package org.apache.shenyu.register.common.path;
  * zookeeper register center.
  */
 public class RegisterPathConstants {
-    
+
+    /**
+     * uri register path pattern.
+     * e.g. /shenyu/register/uri/{rpcType}/{context}/{urlInstance}
+     */
+    public static final String REGISTER_URI_INSTANCE_PATH = "/shenyu/register/uri/*/*/*";
+
+    /**
+     * metadata register path pattern.
+     * e.g. /shenyu/register/metadata/{rpcType}/{context}/{metadata}
+     */
+    public static final String REGISTER_METADATA_INSTANCE_PATH = "/shenyu/register/metadata/*/*/*";
+
     /**
      * root path of zookeeper register center.
      */
@@ -36,18 +48,6 @@ public class RegisterPathConstants {
      * Dot separator.
      */
     private static final String DOT_SEPARATOR = ".";
-
-    /**
-     * uri register path pattern.
-     * e.g. /shenyu/register/uri/{rpcType}/{context}/{urlInstance}
-     */
-    public static final String REGISTER_URI_INSTANCE_PATH = "/shenyu/register/uri/*/*/*";
-
-    /**
-     * metadata register path pattern.
-     * e.g. /shenyu/register/metadata/{rpcType}/{context}/{metadata}
-     */
-    public static final String REGISTER_METADATA_INSTANCE_PATH = "/shenyu/register/metadata/*/*/*";
 
     /**
      * build child path of "/shenyu/register/metadata/{rpcType}/".

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/pom.xml
@@ -33,6 +33,14 @@
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/pom.xml
@@ -31,5 +31,10 @@
             <artifactId>shenyu-register-instance-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/pom.xml
@@ -31,19 +31,5 @@
             <artifactId>shenyu-register-instance-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 </project>

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/main/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperClient.java
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/main/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperClient.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shenyu.common.client.zookeeper;
+package org.apache.shenyu.register.instance.zookeeper;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.framework.CuratorFramework;

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/main/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperConfig.java
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/main/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperConfig.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.register.instance.zookeeper;
+
+public class ZookeeperConfig {
+    /**
+     * zookeeper server list.
+     * e.g. host1:2181,host2:2181
+     */
+    private final String serverLists;
+
+    /**
+     * zookeeper namespace.
+     */
+    private String namespace = "";
+
+    /**
+     * initial amount of time to wait between retries.
+     */
+    private int baseSleepTimeMilliseconds = 1000;
+
+    /**
+     * max time in ms to sleep on each retry.
+     */
+    private int maxSleepTimeMilliseconds = Integer.MAX_VALUE;
+
+    /**
+     * max number of times to retry.
+     */
+    private int maxRetries = 3;
+
+    /**
+     * session timeout.
+     */
+    private int sessionTimeoutMilliseconds = 60 * 1000;
+
+    /**
+     * connection timeout.
+     */
+    private int connectionTimeoutMilliseconds = 15 * 1000;
+
+    /**
+     * auth token digest. no auth by default.
+     */
+    private String digest;
+
+    public ZookeeperConfig(final String serverLists) {
+        this.serverLists = serverLists;
+    }
+
+    /**
+     * get zookeeper server list.
+     * @return server list.
+     */
+    public String getServerLists() {
+        return serverLists;
+    }
+
+    /**
+     * set namespace.
+     * @param namespace zk namespace
+     * @return zk config
+     */
+    public ZookeeperConfig setNamespace(final String namespace) {
+        this.namespace = namespace;
+        return this;
+    }
+
+    /**
+     * get namespace.
+     * @return namespace
+     */
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * get base sleep time.
+     * @return base sleep time.
+     */
+    public int getBaseSleepTimeMilliseconds() {
+        return baseSleepTimeMilliseconds;
+    }
+
+    /**
+     * set base sleep time.
+     * @param baseSleepTimeMilliseconds base sleep time in milliseconds.
+     * @return zk config.
+     */
+    public ZookeeperConfig setBaseSleepTimeMilliseconds(final int baseSleepTimeMilliseconds) {
+        this.baseSleepTimeMilliseconds = baseSleepTimeMilliseconds;
+        return this;
+    }
+
+    /**
+     * get max sleep time.
+     * @return max sleep time
+     */
+    public int getMaxSleepTimeMilliseconds() {
+        return maxSleepTimeMilliseconds;
+    }
+
+    /**
+     * set max sleep time.
+     * @param maxSleepTimeMilliseconds max sleep time.
+     * @return zk config.
+     */
+    public ZookeeperConfig setMaxSleepTimeMilliseconds(final int maxSleepTimeMilliseconds) {
+        this.maxSleepTimeMilliseconds = maxSleepTimeMilliseconds;
+        return this;
+    }
+
+    /**
+     * get max retries.
+     * @return max retries
+     */
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    /**
+     * set max retries count.
+     * @param maxRetries max retries
+     * @return zk config.
+     */
+    public ZookeeperConfig setMaxRetries(final int maxRetries) {
+        this.maxRetries = maxRetries;
+        return this;
+    }
+
+    /**
+     * get session timeout in milliseconds.
+     * @return session timeout.
+     */
+    public int getSessionTimeoutMilliseconds() {
+        return sessionTimeoutMilliseconds;
+    }
+
+    /**
+     * set session timeout in milliseconds.
+     * @param sessionTimeoutMilliseconds session timeout
+     * @return zk config.
+     */
+    public ZookeeperConfig setSessionTimeoutMilliseconds(final int sessionTimeoutMilliseconds) {
+        this.sessionTimeoutMilliseconds = sessionTimeoutMilliseconds;
+        return this;
+    }
+
+    /**
+     * get connection timeout in milliseconds.
+     * @return connection timeout.
+     */
+    public int getConnectionTimeoutMilliseconds() {
+        return connectionTimeoutMilliseconds;
+    }
+
+    /**
+     * set connection timeout in milliseconds.
+     * @param connectionTimeoutMilliseconds connection timeout.
+     * @return zk config.
+     */
+    public ZookeeperConfig setConnectionTimeoutMilliseconds(final int connectionTimeoutMilliseconds) {
+        this.connectionTimeoutMilliseconds = connectionTimeoutMilliseconds;
+        return this;
+    }
+
+    /**
+     * get digest.
+     * @return digest.
+     */
+    public String getDigest() {
+        return digest;
+    }
+
+    /**
+     * set digest.
+     * @param digest digest
+     * @return zk config.
+     */
+    public ZookeeperConfig setDigest(final String digest) {
+        this.digest = digest;
+        return this;
+    }
+}

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/main/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/main/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepository.java
@@ -19,8 +19,6 @@ package org.apache.shenyu.register.instance.zookeeper;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.framework.state.ConnectionState;
-import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
-import org.apache.shenyu.common.client.zookeeper.ZookeeperConfig;
 import org.apache.shenyu.common.config.ShenyuConfig.InstanceConfig;
 import org.apache.shenyu.common.constant.Constants;
 import org.apache.shenyu.common.utils.GsonUtils;

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/main/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/main/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepository.java
@@ -17,8 +17,10 @@
 
 package org.apache.shenyu.register.instance.zookeeper;
 
-import org.I0Itec.zkclient.IZkStateListener;
-import org.I0Itec.zkclient.ZkClient;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
+import org.apache.shenyu.common.client.zookeeper.ZookeeperConfig;
 import org.apache.shenyu.common.config.ShenyuConfig.InstanceConfig;
 import org.apache.shenyu.common.constant.Constants;
 import org.apache.shenyu.common.utils.GsonUtils;
@@ -26,7 +28,7 @@ import org.apache.shenyu.register.common.dto.InstanceRegisterDTO;
 import org.apache.shenyu.register.common.path.RegisterPathConstants;
 import org.apache.shenyu.register.instance.api.ShenyuInstanceRegisterRepository;
 import org.apache.shenyu.spi.Join;
-import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +44,7 @@ public class ZookeeperInstanceRegisterRepository implements ShenyuInstanceRegist
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperInstanceRegisterRepository.class);
 
-    private ZkClient zkClient;
+    private ZookeeperClient client;
 
     private final Map<String, String> nodeDataMap = new HashMap<>();
 
@@ -51,28 +53,54 @@ public class ZookeeperInstanceRegisterRepository implements ShenyuInstanceRegist
         Properties props = config.getProps();
         int sessionTimeout = Integer.parseInt(props.getProperty("sessionTimeout", "3000"));
         int connectionTimeout = Integer.parseInt(props.getProperty("connectionTimeout", "3000"));
-        this.zkClient = new ZkClient(config.getServerLists(), sessionTimeout, connectionTimeout);
-        this.zkClient.subscribeStateChanges(new ZkStateListener());
+
+        int baseSleepTime = Integer.parseInt(props.getProperty("baseSleepTime", "1000"));
+        int maxRetries = Integer.parseInt(props.getProperty("maxRetries", "3"));
+        int maxSleepTime = Integer.parseInt(props.getProperty("maxSleepTime", String.valueOf(Integer.MAX_VALUE)));
+
+        ZookeeperConfig zkConfig = new ZookeeperConfig(config.getServerLists());
+        zkConfig.setBaseSleepTimeMilliseconds(baseSleepTime)
+                .setMaxRetries(maxRetries)
+                .setMaxSleepTimeMilliseconds(maxSleepTime)
+                .setSessionTimeoutMilliseconds(sessionTimeout)
+                .setConnectionTimeoutMilliseconds(connectionTimeout);
+
+        String digest = props.getProperty("digest");
+        if (!StringUtils.isEmpty(digest)) {
+            zkConfig.setDigest(digest);
+        }
+
+        this.client = new ZookeeperClient(zkConfig);
+        this.client.getClient().getConnectionStateListenable().addListener((c, newState) -> {
+            if (newState == ConnectionState.RECONNECTED) {
+                nodeDataMap.forEach((k, v) -> {
+                    if (!client.isExist(k)) {
+                        client.createOrUpdate(k, v, CreateMode.EPHEMERAL);
+                        LOGGER.info("zookeeper client register instance success: {}", v);
+                    }
+                });
+            }
+        });
+
+        client.start();
     }
     
     @Override
     public void persistInstance(final InstanceRegisterDTO instance) {
         String uriNodeName = buildInstanceNodeName(instance);
         String instancePath = RegisterPathConstants.buildInstanceParentPath();
-        if (!zkClient.exists(instancePath)) {
-            zkClient.createPersistent(instancePath, true);
+        if (!client.isExist(instancePath)) {
+            client.createOrUpdate(instancePath, "", CreateMode.PERSISTENT);
         }
         String realNode = RegisterPathConstants.buildRealNode(instancePath, uriNodeName);
-        if (!zkClient.exists(realNode)) {
-            String nodeData = GsonUtils.getInstance().toJson(instance);
-            nodeDataMap.put(realNode, nodeData);
-            zkClient.createEphemeral(realNode, nodeData);
-        }
+        String nodeData = GsonUtils.getInstance().toJson(instance);
+        nodeDataMap.put(realNode, nodeData);
+        client.createOrUpdate(realNode, nodeData, CreateMode.EPHEMERAL);
     }
     
     @Override
     public void close() {
-        zkClient.close();
+        client.close();
     }
 
     private String buildInstanceNodeName(final InstanceRegisterDTO instance) {
@@ -81,25 +109,4 @@ public class ZookeeperInstanceRegisterRepository implements ShenyuInstanceRegist
         return String.join(Constants.COLONS, host, Integer.toString(port));
     }
 
-    private class ZkStateListener implements IZkStateListener {
-        @Override
-        public void handleStateChanged(final Watcher.Event.KeeperState keeperState) {
-            if (Watcher.Event.KeeperState.SyncConnected.equals(keeperState)) {
-                nodeDataMap.forEach((k, v) -> {
-                    if (!zkClient.exists(k)) {
-                        zkClient.createEphemeral(k, v);
-                        LOGGER.info("zookeeper client register success: {}", v);
-                    }
-                });
-            }
-        }
-
-        @Override
-        public void handleNewSession() {
-        }
-
-        @Override
-        public void handleSessionEstablishmentError(final Throwable throwable) {
-        }
-    }
 }

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperClientTest.java
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperClientTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shenyu.common.client.zookeeper;
+package org.apache.shenyu.register.instance.zookeeper;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.CuratorCache;

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepositoryTest.java
@@ -18,7 +18,6 @@
 package org.apache.shenyu.register.instance.zookeeper;
 
 import org.apache.curator.test.TestingServer;
-import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
 import org.apache.shenyu.common.config.ShenyuConfig;
 import org.apache.shenyu.common.utils.GsonUtils;
 import org.apache.shenyu.register.common.dto.InstanceRegisterDTO;

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepositoryTest.java
@@ -1,83 +1,66 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//
-//package org.apache.shenyu.register.instance.zookeeper;
-//
-//import org.I0Itec.zkclient.ZkClient;
-//import org.apache.shenyu.register.common.dto.InstanceRegisterDTO;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//
-//import java.lang.reflect.Field;
-//import java.util.ArrayList;
-//import java.util.HashMap;
-//import java.util.List;
-//import java.util.Map;
-//
-//import static org.junit.Assert.assertEquals;
-//import static org.junit.Assert.assertTrue;
-//import static org.mockito.ArgumentMatchers.anyBoolean;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.Mockito.doAnswer;
-//import static org.mockito.Mockito.mock;
-//
-//public class ZookeeperInstanceRegisterRepositoryTest {
-//
-//    private final List<String> registerPath = new ArrayList<>();
-//
-//    private final Map<String, String> registerInstanceMap
-//            = new HashMap<>();
-//
-//    private final ZookeeperInstanceRegisterRepository repository
-//            = new ZookeeperInstanceRegisterRepository();
-//
-//    @BeforeEach
-//    public void setup() throws Exception {
-//        final ZkClient zkClient = mockZkClient();
-//        final Field field = repository.getClass().getDeclaredField("zkClient");
-//        field.setAccessible(true);
-//        field.set(repository, zkClient);
-//    }
-//
-//    @Test
-//    public void testPersistInstance() {
-//        InstanceRegisterDTO data = InstanceRegisterDTO.builder()
-//                .appName("shenyu-test")
-//                .host("shenyu-host")
-//                .port(9195)
-//                .build();
-//        repository.persistInstance(data);
-//        assertTrue(registerPath.contains("/shenyu/register/instance"));
-//        assertEquals(registerInstanceMap.get("/shenyu/register/instance/shenyu-host:9195"), "{\"appName\":\"shenyu-test\",\"host\":\"shenyu-host\",\"port\":9195}");
-//    }
-//
-//    private ZkClient mockZkClient() {
-//        final ZkClient zkClient = mock(ZkClient.class);
-//        doAnswer(invocation -> {
-//            final String path = invocation.getArgument(0);
-//            registerPath.add(path);
-//            return null;
-//        }).when(zkClient).createPersistent(anyString(), anyBoolean());
-//        doAnswer(invocation -> {
-//            final String path = invocation.getArgument(0);
-//            final String nodeValue = invocation.getArgument(1);
-//            registerInstanceMap.put(path, nodeValue);
-//            return null;
-//        }).when(zkClient).createEphemeral(anyString(), anyString());
-//        return zkClient;
-//    }
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.register.instance.zookeeper;
+
+import org.apache.curator.test.TestingServer;
+import org.apache.shenyu.common.client.zookeeper.ZookeeperClient;
+import org.apache.shenyu.common.config.ShenyuConfig;
+import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.shenyu.register.common.dto.InstanceRegisterDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ZookeeperInstanceRegisterRepositoryTest {
+
+    private final ZookeeperInstanceRegisterRepository repository
+            = new ZookeeperInstanceRegisterRepository();
+
+    private ZookeeperClient client;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        TestingServer server = new TestingServer();
+        ShenyuConfig.InstanceConfig config = new ShenyuConfig.InstanceConfig();
+        config.setServerLists(server.getConnectString());
+        this.repository.init(config);
+
+
+        Class<? extends ZookeeperInstanceRegisterRepository> clazz = this.repository.getClass();
+
+        String fieldString = "client";
+        Field field = clazz.getDeclaredField(fieldString);
+        field.setAccessible(true);
+        this.client = (ZookeeperClient) field.get(repository);
+    }
+
+    @Test
+    public void testPersistInstance() {
+        InstanceRegisterDTO data = InstanceRegisterDTO.builder()
+                .appName("shenyu-test")
+                .host("shenyu-host")
+                .port(9195)
+                .build();
+        repository.persistInstance(data);
+        String value = client.get("/shenyu/register/instance/shenyu-host:9195");
+        assertEquals(value, GsonUtils.getInstance().toJson(data));
+    }
+}

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepositoryTest.java
@@ -1,83 +1,83 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package org.apache.shenyu.register.instance.zookeeper;
-
-import org.I0Itec.zkclient.ZkClient;
-import org.apache.shenyu.register.common.dto.InstanceRegisterDTO;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-
-public class ZookeeperInstanceRegisterRepositoryTest {
-
-    private final List<String> registerPath = new ArrayList<>();
-
-    private final Map<String, String> registerInstanceMap
-            = new HashMap<>();
-
-    private final ZookeeperInstanceRegisterRepository repository
-            = new ZookeeperInstanceRegisterRepository();
-
-    @BeforeEach
-    public void setup() throws Exception {
-        final ZkClient zkClient = mockZkClient();
-        final Field field = repository.getClass().getDeclaredField("zkClient");
-        field.setAccessible(true);
-        field.set(repository, zkClient);
-    }
-
-    @Test
-    public void testPersistInstance() {
-        InstanceRegisterDTO data = InstanceRegisterDTO.builder()
-                .appName("shenyu-test")
-                .host("shenyu-host")
-                .port(9195)
-                .build();
-        repository.persistInstance(data);
-        assertTrue(registerPath.contains("/shenyu/register/instance"));
-        assertEquals(registerInstanceMap.get("/shenyu/register/instance/shenyu-host:9195"), "{\"appName\":\"shenyu-test\",\"host\":\"shenyu-host\",\"port\":9195}");
-    }
-
-    private ZkClient mockZkClient() {
-        final ZkClient zkClient = mock(ZkClient.class);
-        doAnswer(invocation -> {
-            final String path = invocation.getArgument(0);
-            registerPath.add(path);
-            return null;
-        }).when(zkClient).createPersistent(anyString(), anyBoolean());
-        doAnswer(invocation -> {
-            final String path = invocation.getArgument(0);
-            final String nodeValue = invocation.getArgument(1);
-            registerInstanceMap.put(path, nodeValue);
-            return null;
-        }).when(zkClient).createEphemeral(anyString(), anyString());
-        return zkClient;
-    }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one or more
+// * contributor license agreements.  See the NOTICE file distributed with
+// * this work for additional information regarding copyright ownership.
+// * The ASF licenses this file to You under the Apache License, Version 2.0
+// * (the "License"); you may not use this file except in compliance with
+// * the License.  You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package org.apache.shenyu.register.instance.zookeeper;
+//
+//import org.I0Itec.zkclient.ZkClient;
+//import org.apache.shenyu.register.common.dto.InstanceRegisterDTO;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//
+//import java.lang.reflect.Field;
+//import java.util.ArrayList;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertTrue;
+//import static org.mockito.ArgumentMatchers.anyBoolean;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.Mockito.doAnswer;
+//import static org.mockito.Mockito.mock;
+//
+//public class ZookeeperInstanceRegisterRepositoryTest {
+//
+//    private final List<String> registerPath = new ArrayList<>();
+//
+//    private final Map<String, String> registerInstanceMap
+//            = new HashMap<>();
+//
+//    private final ZookeeperInstanceRegisterRepository repository
+//            = new ZookeeperInstanceRegisterRepository();
+//
+//    @BeforeEach
+//    public void setup() throws Exception {
+//        final ZkClient zkClient = mockZkClient();
+//        final Field field = repository.getClass().getDeclaredField("zkClient");
+//        field.setAccessible(true);
+//        field.set(repository, zkClient);
+//    }
+//
+//    @Test
+//    public void testPersistInstance() {
+//        InstanceRegisterDTO data = InstanceRegisterDTO.builder()
+//                .appName("shenyu-test")
+//                .host("shenyu-host")
+//                .port(9195)
+//                .build();
+//        repository.persistInstance(data);
+//        assertTrue(registerPath.contains("/shenyu/register/instance"));
+//        assertEquals(registerInstanceMap.get("/shenyu/register/instance/shenyu-host:9195"), "{\"appName\":\"shenyu-test\",\"host\":\"shenyu-host\",\"port\":9195}");
+//    }
+//
+//    private ZkClient mockZkClient() {
+//        final ZkClient zkClient = mock(ZkClient.class);
+//        doAnswer(invocation -> {
+//            final String path = invocation.getArgument(0);
+//            registerPath.add(path);
+//            return null;
+//        }).when(zkClient).createPersistent(anyString(), anyBoolean());
+//        doAnswer(invocation -> {
+//            final String path = invocation.getArgument(0);
+//            final String nodeValue = invocation.getArgument(1);
+//            registerInstanceMap.put(path, nodeValue);
+//            return null;
+//        }).when(zkClient).createEphemeral(anyString(), anyString());
+//        return zkClient;
+//    }
+//}

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperInstanceRegisterRepositoryTest.java
@@ -43,7 +43,6 @@ public class ZookeeperInstanceRegisterRepositoryTest {
         config.setServerLists(server.getConnectString());
         this.repository.init(config);
 
-
         Class<? extends ZookeeperInstanceRegisterRepository> clazz = this.repository.getClass();
 
         String fieldString = "client";

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/src/main/java/org/apache/shenyu/springboot/sync/data/zookeeper/ZookeeperProperties.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/src/main/java/org/apache/shenyu/springboot/sync/data/zookeeper/ZookeeperProperties.java
@@ -25,7 +25,7 @@ import java.util.StringJoiner;
  * The type Zookeeper configuration.
  */
 @ConfigurationProperties(prefix = "shenyu.sync.zookeeper")
-public class ZookeeperConfig {
+public class ZookeeperProperties {
 
     private String url;
 
@@ -109,7 +109,7 @@ public class ZookeeperConfig {
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", ZookeeperConfig.class.getSimpleName() + "[", "]")
+        return new StringJoiner(", ", ZookeeperProperties.class.getSimpleName() + "[", "]")
                 .add("url='" + url + "'")
                 .add("sessionTimeout=" + sessionTimeout)
                 .add("connectionTimeout=" + connectionTimeout)

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/src/main/java/org/apache/shenyu/springboot/sync/data/zookeeper/ZookeeperSyncDataConfiguration.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/src/main/java/org/apache/shenyu/springboot/sync/data/zookeeper/ZookeeperSyncDataConfiguration.java
@@ -17,11 +17,12 @@
 
 package org.apache.shenyu.springboot.sync.data.zookeeper;
 
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.shenyu.sync.data.api.AuthDataSubscriber;
 import org.apache.shenyu.sync.data.api.MetaDataSubscriber;
 import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
 import org.apache.shenyu.sync.data.api.SyncDataService;
+import org.apache.shenyu.sync.data.zookeeper.ZookeeperClient;
+import org.apache.shenyu.sync.data.zookeeper.ZookeeperConfig;
 import org.apache.shenyu.sync.data.zookeeper.ZookeeperSyncDataService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Zookeeper sync data configuration for spring boot.
@@ -41,7 +43,7 @@ import java.util.List;
 @Configuration
 @ConditionalOnClass(ZookeeperSyncDataService.class)
 @ConditionalOnProperty(prefix = "shenyu.sync.zookeeper", name = "url")
-@EnableConfigurationProperties(ZookeeperConfig.class)
+@EnableConfigurationProperties(ZookeeperProperties.class)
 public class ZookeeperSyncDataConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperSyncDataConfiguration.class);
@@ -49,28 +51,35 @@ public class ZookeeperSyncDataConfiguration {
     /**
      * Sync data service sync data service.
      *
-     * @param zkClient the zk client
+     * @param zookeeperClient  the zk client
      * @param pluginSubscriber the plugin subscriber
-     * @param metaSubscribers the meta subscribers
-     * @param authSubscribers the auth subscribers
+     * @param metaSubscribers  the meta subscribers
+     * @param authSubscribers  the auth subscribers
      * @return the sync data service
      */
     @Bean
-    public SyncDataService syncDataService(final ObjectProvider<ZkClient> zkClient, final ObjectProvider<PluginDataSubscriber> pluginSubscriber,
+    public SyncDataService syncDataService(final ObjectProvider<ZookeeperClient> zookeeperClient, final ObjectProvider<PluginDataSubscriber> pluginSubscriber,
                                            final ObjectProvider<List<MetaDataSubscriber>> metaSubscribers, final ObjectProvider<List<AuthDataSubscriber>> authSubscribers) {
         LOGGER.info("you use zookeeper sync shenyu data.......");
-        return new ZookeeperSyncDataService(zkClient.getIfAvailable(), pluginSubscriber.getIfAvailable(),
+        return new ZookeeperSyncDataService(zookeeperClient.getIfAvailable(), pluginSubscriber.getIfAvailable(),
                 metaSubscribers.getIfAvailable(Collections::emptyList), authSubscribers.getIfAvailable(Collections::emptyList));
     }
 
     /**
      * register zkClient in spring ioc.
      *
-     * @param zookeeperConfig the zookeeper configuration
-     * @return ZkClient {@linkplain ZkClient}
+     * @param zookeeperProps the zookeeper configuration
+     * @return ZookeeperClient {@linkplain ZookeeperClient}
      */
     @Bean
-    public ZkClient zkClient(final ZookeeperConfig zookeeperConfig) {
-        return new ZkClient(zookeeperConfig.getUrl(), zookeeperConfig.getSessionTimeout(), zookeeperConfig.getConnectionTimeout());
+    public ZookeeperClient zookeeperClient(final ZookeeperProperties zookeeperProps) {
+        int sessionTimeout = Objects.isNull(zookeeperProps.getSessionTimeout()) ? 3000 : zookeeperProps.getSessionTimeout();
+        int connectionTimeout = Objects.isNull(zookeeperProps.getConnectionTimeout()) ? 3000 : zookeeperProps.getConnectionTimeout();
+        ZookeeperConfig zkConfig = new ZookeeperConfig(zookeeperProps.getUrl());
+        zkConfig.setSessionTimeoutMilliseconds(sessionTimeout)
+                .setConnectionTimeoutMilliseconds(connectionTimeout);
+        ZookeeperClient client = new ZookeeperClient(zkConfig);
+        client.start();
+        return client;
     }
 }

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/src/test/java/org/apache/shenyu/springboot/sync/data/zookeeper/ZookeeperSyncDataConfigurationTest.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/src/test/java/org/apache/shenyu/springboot/sync/data/zookeeper/ZookeeperSyncDataConfigurationTest.java
@@ -22,9 +22,9 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.I0Itec.zkclient.ZkClient;
 import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
 import org.apache.shenyu.sync.data.api.SyncDataService;
+import org.apache.shenyu.sync.data.zookeeper.ZookeeperClient;
 import org.apache.shenyu.sync.data.zookeeper.ZookeeperSyncDataService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,11 +49,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
                 "shenyu.sync.zookeeper.connectionTimeout=500"
         })
 @EnableAutoConfiguration
-@MockBean({PluginDataSubscriber.class, ZkClient.class})
+@MockBean({PluginDataSubscriber.class, ZookeeperClient.class})
 public final class ZookeeperSyncDataConfigurationTest {
 
     @Autowired
-    private ZookeeperConfig zookeeperConfig;
+    private ZookeeperProperties zookeeperConfig;
 
     @Autowired
     private SyncDataService syncDataService;
@@ -68,7 +68,7 @@ public final class ZookeeperSyncDataConfigurationTest {
     }
 
     /**
-     * case to test {@link ZookeeperSyncDataConfiguration} to register bean {@link ZookeeperConfig}.
+     * case to test {@link ZookeeperSyncDataConfiguration} to register bean {@link ZookeeperProperties}.
      */
     @Test
     public void testZookeeperSyncDataConfigurationRegisterBeanZookeeperConfig() {

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml
@@ -31,25 +31,18 @@
             <artifactId>shenyu-sync-data-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>slf4j-log4j12</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>${curator.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>${curator-test.version}</version>
+            <version>${curator.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperClient.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperClient.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.sync.data.zookeeper;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.shenyu.common.exception.ShenyuException;
+import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.zookeeper.CreateMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ZookeeperClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperClient.class);
+
+    private final ZookeeperConfig config;
+
+    private final CuratorFramework client;
+
+    private final Map<String, CuratorCache> caches = new ConcurrentHashMap<>();
+
+    public ZookeeperClient(final ZookeeperConfig zookeeperConfig) {
+        this.config = zookeeperConfig;
+        ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(config.getBaseSleepTimeMilliseconds(), config.getMaxRetries(), config.getMaxSleepTimeMilliseconds());
+
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
+                .connectString(config.getServerLists())
+                .retryPolicy(retryPolicy)
+                .connectionTimeoutMs(config.getConnectionTimeoutMilliseconds())
+                .sessionTimeoutMs(config.getSessionTimeoutMilliseconds())
+                .namespace(config.getNamespace());
+
+        if (!StringUtils.isEmpty(config.getDigest())) {
+            builder.authorization("digest", config.getDigest().getBytes(StandardCharsets.UTF_8));
+        }
+
+        this.client = builder.build();
+    }
+
+    /**
+     * start.
+     */
+    public void start() {
+        this.client.start();
+        try {
+            this.client.blockUntilConnected();
+        } catch (InterruptedException e) {
+            LOGGER.warn("Interrupted during zookeeper client starting.");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * start.
+     */
+    public void close() {
+        // close all caches
+        for (Map.Entry<String, CuratorCache> cache : caches.entrySet()) {
+            CloseableUtils.closeQuietly(cache.getValue());
+        }
+        // close client
+        CloseableUtils.closeQuietly(client);
+    }
+
+    /**
+     * get curator framework.
+     *
+     * @return curator framework client.
+     */
+    public CuratorFramework getClient() {
+        return client;
+    }
+
+    /**
+     * check if key exist.
+     *
+     * @param key zookeeper path
+     * @return if exist.
+     */
+    public boolean isExist(final String key) {
+        try {
+            return null != client.checkExists().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get from zk directly.
+     *
+     * @param key zookeeper path
+     * @return value.
+     */
+    public String getDirectly(final String key) {
+        try {
+            byte[] ret = client.getData().forPath(key);
+            return Objects.isNull(ret) ? null : new String(ret, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get value for specific key.
+     *
+     * @param key zookeeper path
+     * @return value.
+     */
+    public String get(final String key) {
+        CuratorCache cache = findFromcache(key);
+        if (Objects.isNull(cache)) {
+            return getDirectly(key);
+        }
+        Optional<ChildData> data = cache.get(key);
+        return data.map(childData -> new String(childData.getData(), StandardCharsets.UTF_8)).orElseGet(() -> getDirectly(key));
+    }
+
+    /**
+     * create or update key with value.
+     *
+     * @param key   zookeeper path key.
+     * @param value string value.
+     * @param mode  creation mode.
+     */
+    public void createOrUpdate(final String key, final String value, final CreateMode mode) {
+        String val = StringUtils.isEmpty(value) ? "" : value;
+        try {
+            client.create().orSetData().creatingParentsIfNeeded().withMode(mode).forPath(key, val.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * create or update key with value.
+     *
+     * @param key   zookeeper path key.
+     * @param value object value.
+     * @param mode  creation mode.
+     */
+    public void createOrUpdate(final String key, final Object value, final CreateMode mode) {
+        if (value != null) {
+            String val = GsonUtils.getInstance().toJson(value);
+            createOrUpdate(key, val, mode);
+        } else {
+            createOrUpdate(key, "", mode);
+        }
+    }
+
+    /**
+     * delete a node with specific key.
+     *
+     * @param key zookeeper path key.
+     */
+    public void delete(final String key) {
+        try {
+            client.delete().deletingChildrenIfNeeded().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get children with specific key.
+     *
+     * @param key zookeeper key.
+     * @return children node name.
+     */
+    public List<String> getChildren(final String key) {
+        try {
+            return client.getChildren().forPath(key);
+        } catch (Exception e) {
+            throw new ShenyuException(e);
+        }
+    }
+
+    /**
+     * get created cache.
+     * @param path path.
+     * @return cache.
+     */
+    public CuratorCache getCache(final String path) {
+        return caches.get(path);
+    }
+
+    /**
+     * add new curator cache.
+     * @param path path.
+     * @param listeners listeners.
+     * @return cache.
+     */
+    public CuratorCache addCache(final String path, final CuratorCacheListener... listeners) {
+        CuratorCache cache = CuratorCache.build(client, path);
+        caches.put(path, cache);
+        if (listeners != null && listeners.length > 0) {
+            for (CuratorCacheListener listener : listeners) {
+                cache.listenable().addListener(listener);
+            }
+        }
+        cache.start();
+        return cache;
+    }
+
+    /**
+     * find cache with  key.
+     * @param key key.
+     * @return cache.
+     */
+    private CuratorCache findFromcache(final String key) {
+        for (Map.Entry<String, CuratorCache> cache : caches.entrySet()) {
+            if (key.startsWith(cache.getKey())) {
+                return cache.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperConfig.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperConfig.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.sync.data.zookeeper;
+
+public class ZookeeperConfig {
+    /**
+     * zookeeper server list.
+     * e.g. host1:2181,host2:2181
+     */
+    private final String serverLists;
+
+    /**
+     * zookeeper namespace.
+     */
+    private String namespace = "";
+
+    /**
+     * initial amount of time to wait between retries.
+     */
+    private int baseSleepTimeMilliseconds = 1000;
+
+    /**
+     * max time in ms to sleep on each retry.
+     */
+    private int maxSleepTimeMilliseconds = Integer.MAX_VALUE;
+
+    /**
+     * max number of times to retry.
+     */
+    private int maxRetries = 3;
+
+    /**
+     * session timeout.
+     */
+    private int sessionTimeoutMilliseconds = 60 * 1000;
+
+    /**
+     * connection timeout.
+     */
+    private int connectionTimeoutMilliseconds = 15 * 1000;
+
+    /**
+     * auth token digest. no auth by default.
+     */
+    private String digest;
+
+    public ZookeeperConfig(final String serverLists) {
+        this.serverLists = serverLists;
+    }
+
+    /**
+     * get zookeeper server list.
+     * @return server list.
+     */
+    public String getServerLists() {
+        return serverLists;
+    }
+
+    /**
+     * set namespace.
+     * @param namespace zk namespace
+     * @return zk config
+     */
+    public ZookeeperConfig setNamespace(final String namespace) {
+        this.namespace = namespace;
+        return this;
+    }
+
+    /**
+     * get namespace.
+     * @return namespace
+     */
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * get base sleep time.
+     * @return base sleep time.
+     */
+    public int getBaseSleepTimeMilliseconds() {
+        return baseSleepTimeMilliseconds;
+    }
+
+    /**
+     * set base sleep time.
+     * @param baseSleepTimeMilliseconds base sleep time in milliseconds.
+     * @return zk config.
+     */
+    public ZookeeperConfig setBaseSleepTimeMilliseconds(final int baseSleepTimeMilliseconds) {
+        this.baseSleepTimeMilliseconds = baseSleepTimeMilliseconds;
+        return this;
+    }
+
+    /**
+     * get max sleep time.
+     * @return max sleep time
+     */
+    public int getMaxSleepTimeMilliseconds() {
+        return maxSleepTimeMilliseconds;
+    }
+
+    /**
+     * set max sleep time.
+     * @param maxSleepTimeMilliseconds max sleep time.
+     * @return zk config.
+     */
+    public ZookeeperConfig setMaxSleepTimeMilliseconds(final int maxSleepTimeMilliseconds) {
+        this.maxSleepTimeMilliseconds = maxSleepTimeMilliseconds;
+        return this;
+    }
+
+    /**
+     * get max retries.
+     * @return max retries
+     */
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    /**
+     * set max retries count.
+     * @param maxRetries max retries
+     * @return zk config.
+     */
+    public ZookeeperConfig setMaxRetries(final int maxRetries) {
+        this.maxRetries = maxRetries;
+        return this;
+    }
+
+    /**
+     * get session timeout in milliseconds.
+     * @return session timeout.
+     */
+    public int getSessionTimeoutMilliseconds() {
+        return sessionTimeoutMilliseconds;
+    }
+
+    /**
+     * set session timeout in milliseconds.
+     * @param sessionTimeoutMilliseconds session timeout
+     * @return zk config.
+     */
+    public ZookeeperConfig setSessionTimeoutMilliseconds(final int sessionTimeoutMilliseconds) {
+        this.sessionTimeoutMilliseconds = sessionTimeoutMilliseconds;
+        return this;
+    }
+
+    /**
+     * get connection timeout in milliseconds.
+     * @return connection timeout.
+     */
+    public int getConnectionTimeoutMilliseconds() {
+        return connectionTimeoutMilliseconds;
+    }
+
+    /**
+     * set connection timeout in milliseconds.
+     * @param connectionTimeoutMilliseconds connection timeout.
+     * @return zk config.
+     */
+    public ZookeeperConfig setConnectionTimeoutMilliseconds(final int connectionTimeoutMilliseconds) {
+        this.connectionTimeoutMilliseconds = connectionTimeoutMilliseconds;
+        return this;
+    }
+
+    /**
+     * get digest.
+     * @return digest.
+     */
+    public String getDigest() {
+        return digest;
+    }
+
+    /**
+     * set digest.
+     * @param digest digest
+     * @return zk config.
+     */
+    public ZookeeperConfig setDigest(final String digest) {
+        this.digest = digest;
+        return this;
+    }
+}

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataService.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataService.java
@@ -19,21 +19,23 @@ package org.apache.shenyu.sync.data.zookeeper;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
-import org.I0Itec.zkclient.IZkDataListener;
-import org.I0Itec.zkclient.ZkClient;
-import org.apache.commons.collections4.CollectionUtils;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
 import org.apache.shenyu.common.constant.DefaultPathConstants;
 import org.apache.shenyu.common.dto.AppAuthData;
 import org.apache.shenyu.common.dto.MetaData;
 import org.apache.shenyu.common.dto.PluginData;
 import org.apache.shenyu.common.dto.RuleData;
 import org.apache.shenyu.common.dto.SelectorData;
-import org.apache.shenyu.common.enums.ConfigGroupEnum;
+import org.apache.shenyu.common.exception.ShenyuException;
 import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.shenyu.common.utils.PathMatchUtils;
 import org.apache.shenyu.sync.data.api.AuthDataSubscriber;
 import org.apache.shenyu.sync.data.api.MetaDataSubscriber;
 import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
 import org.apache.shenyu.sync.data.api.SyncDataService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -41,14 +43,15 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * this cache data with zookeeper.
  */
 public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable {
 
-    private final ZkClient zkClient;
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperSyncDataService.class);
+
+    private final ZookeeperClient zkClient;
 
     private final PluginDataSubscriber pluginDataSubscriber;
 
@@ -64,7 +67,7 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
      * @param metaDataSubscribers  the meta data subscribers
      * @param authDataSubscribers  the auth data subscribers
      */
-    public ZookeeperSyncDataService(final ZkClient zkClient,
+    public ZookeeperSyncDataService(final ZookeeperClient zkClient,
                                     final PluginDataSubscriber pluginDataSubscriber,
                                     final List<MetaDataSubscriber> metaDataSubscribers,
                                     final List<AuthDataSubscriber> authDataSubscribers) {
@@ -78,251 +81,17 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
     }
 
     private void watcherData() {
-        final String pluginParent = DefaultPathConstants.PLUGIN_PARENT;
-        List<String> pluginZKs = zkClientGetChildren(pluginParent);
-        for (String pluginName : pluginZKs) {
-            watcherAll(pluginName);
-        }
-        zkClient.subscribeChildChanges(pluginParent, (parentPath, currentChildren) -> {
-            if (CollectionUtils.isNotEmpty(currentChildren)) {
-                for (String pluginName : currentChildren) {
-                    watcherAll(pluginName);
-                }
-            }
-        });
-    }
-
-    private void watcherAll(final String pluginName) {
-        watcherPlugin(pluginName);
-        watcherSelector(pluginName);
-        watcherRule(pluginName);
-    }
-
-    private void watcherPlugin(final String pluginName) {
-        String pluginPath = DefaultPathConstants.buildPluginPath(pluginName);
-        if (!zkClient.exists(pluginPath)) {
-            zkClient.createPersistent(pluginPath, true);
-        }
-
-        PluginData pluginData = Optional.ofNullable(zkClient.readData(pluginPath))
-                .map(data -> GsonUtils.getInstance().fromJson((String) data, PluginData.class))
-                .orElse(null);
-        cachePluginData(pluginData);
-        subscribePluginDataChanges(pluginPath, pluginName);
-    }
-
-    private void watcherSelector(final String pluginName) {
-        String selectorParentPath = DefaultPathConstants.buildSelectorParentPath(pluginName);
-        List<String> childrenList = zkClientGetChildren(selectorParentPath);
-        if (CollectionUtils.isNotEmpty(childrenList)) {
-            childrenList.forEach(children -> {
-                String realPath = buildRealPath(selectorParentPath, children);
-                SelectorData selectorData = Optional.ofNullable(zkClient.readData(realPath))
-                        .map(data -> GsonUtils.getInstance().fromJson((String) data, SelectorData.class))
-                        .orElse(null);
-                cacheSelectorData(selectorData);
-                subscribeSelectorDataChanges(realPath);
-            });
-        }
-        subscribeChildChanges(ConfigGroupEnum.SELECTOR, selectorParentPath, childrenList);
-    }
-
-    private void watcherRule(final String pluginName) {
-        String ruleParent = DefaultPathConstants.buildRuleParentPath(pluginName);
-        List<String> childrenList = zkClientGetChildren(ruleParent);
-        if (CollectionUtils.isNotEmpty(childrenList)) {
-            childrenList.forEach(children -> {
-                String realPath = buildRealPath(ruleParent, children);
-                RuleData ruleData = Optional.ofNullable(zkClient.readData(realPath))
-                        .map(data -> GsonUtils.getInstance().fromJson((String) data, RuleData.class))
-                        .orElse(null);
-                cacheRuleData(ruleData);
-                subscribeRuleDataChanges(realPath);
-            });
-        }
-        subscribeChildChanges(ConfigGroupEnum.RULE, ruleParent, childrenList);
+        zkClient.addCache(DefaultPathConstants.PLUGIN_PARENT, new PluginCacheListener());
+        zkClient.addCache(DefaultPathConstants.SELECTOR_PARENT, new SelectorCacheListener());
+        zkClient.addCache(DefaultPathConstants.RULE_PARENT, new RuleCacheListener());
     }
 
     private void watchAppAuth() {
-        final String appAuthParent = DefaultPathConstants.APP_AUTH_PARENT;
-        List<String> childrenList = zkClientGetChildren(appAuthParent);
-        if (CollectionUtils.isNotEmpty(childrenList)) {
-            childrenList.forEach(children -> {
-                String realPath = buildRealPath(appAuthParent, children);
-                AppAuthData appAuthData = Optional.ofNullable(zkClient.readData(realPath))
-                        .map(data -> GsonUtils.getInstance().fromJson((String) data, AppAuthData.class))
-                        .orElse(null);
-                cacheAuthData(appAuthData);
-                subscribeAppAuthDataChanges(realPath);
-            });
-        }
-        subscribeChildChanges(ConfigGroupEnum.APP_AUTH, appAuthParent, childrenList);
+        zkClient.addCache(DefaultPathConstants.APP_AUTH_PARENT, new AuthCacheListener());
     }
 
     private void watchMetaData() {
-        final String metaDataPath = DefaultPathConstants.META_DATA;
-        List<String> childrenList = zkClientGetChildren(metaDataPath);
-        if (CollectionUtils.isNotEmpty(childrenList)) {
-            childrenList.forEach(children -> {
-                String realPath = buildRealPath(metaDataPath, children);
-                MetaData metaData = Optional.ofNullable(zkClient.readData(realPath))
-                        .map(data -> GsonUtils.getInstance().fromJson((String) data, MetaData.class))
-                        .orElse(null);
-                cacheMetaData(metaData);
-                subscribeMetaDataChanges(realPath);
-            });
-        }
-        subscribeChildChanges(ConfigGroupEnum.META_DATA, metaDataPath, childrenList);
-    }
-
-    private void subscribeChildChanges(final ConfigGroupEnum groupKey, final String groupParentPath, final List<String> childrenList) {
-        switch (groupKey) {
-            case SELECTOR:
-                zkClient.subscribeChildChanges(groupParentPath, (parentPath, currentChildren) -> {
-                    if (CollectionUtils.isNotEmpty(currentChildren)) {
-                        List<String> addSubscribePath = addSubscribePath(childrenList, currentChildren);
-                        addSubscribePath.stream().map(addPath -> {
-                            String realPath = buildRealPath(parentPath, addPath);
-                            SelectorData selectorData = Optional.ofNullable(zkClient.readData(realPath))
-                                    .map(data -> GsonUtils.getInstance().fromJson((String) data, SelectorData.class))
-                                    .orElse(null);
-                            cacheSelectorData(selectorData);
-                            return realPath;
-                        }).forEach(this::subscribeSelectorDataChanges);
-                    }
-                });
-                break;
-            case RULE:
-                zkClient.subscribeChildChanges(groupParentPath, (parentPath, currentChildren) -> {
-                    if (CollectionUtils.isNotEmpty(currentChildren)) {
-                        List<String> addSubscribePath = addSubscribePath(childrenList, currentChildren);
-                        // Get the newly added node data and subscribe to that node
-                        addSubscribePath.stream().map(addPath -> {
-                            String realPath = buildRealPath(parentPath, addPath);
-                            RuleData ruleData = Optional.ofNullable(zkClient.readData(realPath))
-                                    .map(data -> GsonUtils.getInstance().fromJson((String) data, RuleData.class))
-                                    .orElse(null);
-                            cacheRuleData(ruleData);
-                            return realPath;
-                        }).forEach(this::subscribeRuleDataChanges);
-                    }
-                });
-                break;
-            case APP_AUTH:
-                zkClient.subscribeChildChanges(groupParentPath, (parentPath, currentChildren) -> {
-                    if (CollectionUtils.isNotEmpty(currentChildren)) {
-                        final List<String> addSubscribePath = addSubscribePath(childrenList, currentChildren);
-                        addSubscribePath.stream().map(children -> {
-                            final String realPath = buildRealPath(parentPath, children);
-                            AppAuthData appAuthData = Optional.ofNullable(zkClient.readData(realPath))
-                                    .map(data -> GsonUtils.getInstance().fromJson((String) data, AppAuthData.class))
-                                    .orElse(null);
-                            cacheAuthData(appAuthData);
-                            return realPath;
-                        }).forEach(this::subscribeAppAuthDataChanges);
-                    }
-                });
-                break;
-            case META_DATA:
-                zkClient.subscribeChildChanges(groupParentPath, (parentPath, currentChildren) -> {
-                    if (CollectionUtils.isNotEmpty(currentChildren)) {
-                        final List<String> addSubscribePath = addSubscribePath(childrenList, currentChildren);
-                        addSubscribePath.stream().map(children -> {
-                            final String realPath = buildRealPath(parentPath, children);
-                            MetaData metaData = Optional.ofNullable(zkClient.readData(realPath))
-                                    .map(data -> GsonUtils.getInstance().fromJson((String) data, MetaData.class))
-                                    .orElse(null);
-                            cacheMetaData(metaData);
-                            return realPath;
-                        }).forEach(this::subscribeMetaDataChanges);
-                    }
-                });
-                break;
-            default:
-                throw new IllegalStateException("Unexpected groupKey: " + groupKey);
-        }
-    }
-
-    private void subscribePluginDataChanges(final String pluginPath, final String pluginName) {
-        zkClient.subscribeDataChanges(pluginPath, new IZkDataListener() {
-
-            @Override
-            public void handleDataChange(final String dataPath, final Object data) {
-                Optional.ofNullable(data)
-                        .flatMap(d -> Optional.ofNullable(pluginDataSubscriber))
-                        .ifPresent(e -> e.onSubscribe(GsonUtils.getInstance().fromJson(data.toString(), PluginData.class)));
-            }
-
-            @Override
-            public void handleDataDeleted(final String dataPath) {
-                final PluginData data = new PluginData();
-                data.setName(pluginName);
-                Optional.ofNullable(pluginDataSubscriber).ifPresent(e -> e.unSubscribe(data));
-            }
-        });
-    }
-
-    private void subscribeSelectorDataChanges(final String path) {
-        zkClient.subscribeDataChanges(path, new IZkDataListener() {
-            @Override
-            public void handleDataChange(final String dataPath, final Object data) {
-                Optional.ofNullable(data)
-                        .ifPresent(e -> cacheSelectorData(GsonUtils.getInstance().fromJson(data.toString(), SelectorData.class)));
-            }
-
-            @Override
-            public void handleDataDeleted(final String dataPath) {
-                unCacheSelectorData(dataPath);
-            }
-        });
-    }
-
-    private void subscribeRuleDataChanges(final String path) {
-        zkClient.subscribeDataChanges(path, new IZkDataListener() {
-            @Override
-            public void handleDataChange(final String dataPath, final Object data) {
-                Optional.ofNullable(data)
-                        .ifPresent(e -> cacheRuleData(GsonUtils.getInstance().fromJson(data.toString(), RuleData.class)));
-            }
-
-            @Override
-            public void handleDataDeleted(final String dataPath) {
-                unCacheRuleData(dataPath);
-            }
-        });
-    }
-
-    private void subscribeAppAuthDataChanges(final String realPath) {
-        zkClient.subscribeDataChanges(realPath, new IZkDataListener() {
-            @Override
-            public void handleDataChange(final String dataPath, final Object data) {
-                Optional.ofNullable(data)
-                        .ifPresent(e -> cacheAuthData(GsonUtils.getInstance().fromJson(data.toString(), AppAuthData.class)));
-            }
-
-            @Override
-            public void handleDataDeleted(final String dataPath) {
-                unCacheAuthData(dataPath);
-            }
-        });
-    }
-
-    private void subscribeMetaDataChanges(final String realPath) {
-        zkClient.subscribeDataChanges(realPath, new IZkDataListener() {
-            @Override
-            public void handleDataChange(final String dataPath, final Object data) {
-                Optional.ofNullable(data)
-                        .ifPresent(e -> cacheMetaData(GsonUtils.getInstance().fromJson(data.toString(), MetaData.class)));
-            }
-
-            @Override
-            public void handleDataDeleted(final String dataPath) throws UnsupportedEncodingException {
-                final String realPath = dataPath.substring(DefaultPathConstants.META_DATA.length() + 1);
-                MetaData metaData = new MetaData();
-                metaData.setPath(URLDecoder.decode(realPath, StandardCharsets.UTF_8.name()));
-                unCacheMetaData(metaData);
-            }
-        });
+        zkClient.addCache(DefaultPathConstants.META_DATA, new MetadataCacheListener());
     }
 
     private void cachePluginData(final PluginData pluginData) {
@@ -334,7 +103,7 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
     private void cacheSelectorData(final SelectorData selectorData) {
         Optional.ofNullable(selectorData)
                 .ifPresent(data -> Optional.ofNullable(pluginDataSubscriber)
-                                           .ifPresent(e -> e.onSelectorSubscribe(data)));
+                        .ifPresent(e -> e.onSelectorSubscribe(data)));
     }
 
     private void unCacheSelectorData(final String dataPath) {
@@ -352,7 +121,7 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
     private void cacheRuleData(final RuleData ruleData) {
         Optional.ofNullable(ruleData)
                 .ifPresent(data -> Optional.ofNullable(pluginDataSubscriber)
-                                           .ifPresent(e -> e.onRuleSubscribe(data)));
+                        .ifPresent(e -> e.onRuleSubscribe(data)));
     }
 
     private void unCacheRuleData(final String dataPath) {
@@ -392,32 +161,140 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
                 .ifPresent(data -> metaDataSubscribers.forEach(e -> e.unSubscribe(metaData)));
     }
 
-    private List<String> addSubscribePath(final List<String> alreadyChildren,
-                                          final List<String> currentChildren) {
-        if (CollectionUtils.isEmpty(alreadyChildren)) {
-            return currentChildren;
-        }
-
-        return currentChildren.stream()
-                .filter(current -> alreadyChildren.stream().noneMatch(current::equals))
-                .collect(Collectors.toList());
-    }
-
-    private String buildRealPath(final String parent, final String children) {
-        return parent + "/" + children;
-    }
-
-    private List<String> zkClientGetChildren(final String parent) {
-        if (!zkClient.exists(parent)) {
-            zkClient.createPersistent(parent, true);
-        }
-        return zkClient.getChildren(parent);
-    }
-
     @Override
     public void close() {
         if (Objects.nonNull(zkClient)) {
             zkClient.close();
         }
     }
+
+    class PluginCacheListener implements CuratorCacheListener {
+
+        private static final String PLUGIN_PATH = DefaultPathConstants.PLUGIN_PARENT + "/*";
+
+        @Override
+        public void event(final Type type, final ChildData oldData, final ChildData data) {
+            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
+
+            // if not uri register path, return.
+            if (!PathMatchUtils.match(PLUGIN_PATH, path)) {
+                return;
+            }
+
+            String pluginName = path.substring(path.lastIndexOf("/") + 1);
+
+            // delete a plugin
+            if (type.equals(Type.NODE_DELETED)) {
+                final PluginData pluginData = new PluginData();
+                pluginData.setName(pluginName);
+                Optional.ofNullable(pluginDataSubscriber).ifPresent(e -> e.unSubscribe(pluginData));
+            }
+
+            // create or update
+            Optional.ofNullable(data)
+                    .ifPresent(e -> cachePluginData(GsonUtils.getInstance().fromJson(new String(data.getData(), StandardCharsets.UTF_8), PluginData.class)));
+        }
+    }
+
+    class SelectorCacheListener implements CuratorCacheListener {
+
+        // /shenyu/selector/{plugin}/{selector}
+        private static final String SELECTOR_PATH = DefaultPathConstants.SELECTOR_PARENT + "/*/*";
+
+        @Override
+        public void event(final Type type, final ChildData oldData, final ChildData data) {
+            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
+
+            // if not uri register path, return.
+            if (!PathMatchUtils.match(SELECTOR_PATH, path)) {
+                return;
+            }
+
+            if (type.equals(Type.NODE_DELETED)) {
+                unCacheSelectorData(path);
+            }
+
+            // create or update
+            Optional.ofNullable(data)
+                    .ifPresent(e -> cacheSelectorData(GsonUtils.getInstance().fromJson(new String(data.getData(), StandardCharsets.UTF_8), SelectorData.class)));
+        }
+    }
+
+    class MetadataCacheListener implements CuratorCacheListener {
+
+        private static final String META_DATA_PATH = DefaultPathConstants.META_DATA + "/*";
+
+        @Override
+        public void event(final Type type, final ChildData oldData, final ChildData data) {
+            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
+
+            // if not uri register path, return.
+            if (!PathMatchUtils.match(META_DATA_PATH, path)) {
+                return;
+            }
+
+            if (type.equals(Type.NODE_DELETED)) {
+                final String realPath = path.substring(DefaultPathConstants.META_DATA.length() + 1);
+                MetaData metaData = new MetaData();
+                try {
+                    metaData.setPath(URLDecoder.decode(realPath, StandardCharsets.UTF_8.name()));
+                } catch (UnsupportedEncodingException e) {
+                    throw new ShenyuException(e);
+                }
+                unCacheMetaData(metaData);
+            }
+
+            // create or update
+            Optional.ofNullable(data)
+                    .ifPresent(e -> cacheMetaData(GsonUtils.getInstance().fromJson(new String(data.getData(), StandardCharsets.UTF_8), MetaData.class)));
+        }
+    }
+
+    class AuthCacheListener implements CuratorCacheListener {
+
+        private static final String APP_AUTH_PATH = DefaultPathConstants.APP_AUTH_PARENT + "/*";
+
+        @Override
+        public void event(final Type type, final ChildData oldData, final ChildData data) {
+            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
+
+            // if not uri register path, return.
+            if (!PathMatchUtils.match(APP_AUTH_PATH, path)) {
+                return;
+            }
+
+            if (type.equals(Type.NODE_DELETED)) {
+                unCacheAuthData(path);
+            }
+
+            // create or update
+            Optional.ofNullable(data)
+                    .ifPresent(e -> cacheAuthData(GsonUtils.getInstance().fromJson(new String(data.getData(), StandardCharsets.UTF_8), AppAuthData.class)));
+        }
+    }
+
+    class RuleCacheListener implements CuratorCacheListener {
+
+        // /shenyu/rule/{plugin}/{rule}
+        private static final String RULE_PATH = DefaultPathConstants.RULE_PARENT + "/*/*";
+
+        @Override
+        public void event(final Type type, final ChildData oldData, final ChildData data) {
+            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
+
+            // if not uri register path, return.
+            if (!PathMatchUtils.match(RULE_PATH, path)) {
+                return;
+            }
+
+            if (type.equals(Type.NODE_DELETED)) {
+                unCacheRuleData(path);
+            }
+
+            // create or update
+            Optional.ofNullable(data)
+                    .ifPresent(e -> cacheRuleData(GsonUtils.getInstance().fromJson(new String(data.getData(), StandardCharsets.UTF_8), RuleData.class)));
+        }
+    }
+
 }

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/test/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/test/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java
@@ -103,7 +103,7 @@ public final class ZookeeperSyncDataServiceTest {
             }
         }, Collections.emptyList(), Collections.emptyList());
         // wait for listener taking action
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(subscribeList.size(), is(1));
         assertThat(subscribeList.get(0).getName(), is("divide"));
     }
@@ -121,7 +121,7 @@ public final class ZookeeperSyncDataServiceTest {
         PluginData pluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.FALSE).build();
         zkClient.createOrUpdate(MOCK_PLUGIN_PATH, pluginData, CreateMode.PERSISTENT);
         // wait for listener taking action
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(subscribeList.size(), is(1));
         assertThat(subscribeList.get(0).getName(), is("divide"));
     }
@@ -138,10 +138,10 @@ public final class ZookeeperSyncDataServiceTest {
                 unSubscribeList.add(pluginData);
             }
         }, Collections.emptyList(), Collections.emptyList());
-        Thread.sleep(200);
+        Thread.sleep(500);
         zkClient.delete(MOCK_PLUGIN_PATH);
         // wait for listener taking action
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(unSubscribeList.size(), is(1));
         assertThat(unSubscribeList.get(0).getName(), is("divide"));
     }
@@ -157,7 +157,7 @@ public final class ZookeeperSyncDataServiceTest {
                 subscribeList.add(selectorData);
             }
         }, Collections.emptyList(), Collections.emptyList());
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(subscribeList.size(), is(1));
         assertThat(subscribeList.get(0).getName(), is("test"));
     }
@@ -173,9 +173,9 @@ public final class ZookeeperSyncDataServiceTest {
                 subscribeList.add(selectorData);
             }
         }, Collections.emptyList(), Collections.emptyList());
-        Thread.sleep(200);
+        Thread.sleep(500);
         zkClient.createOrUpdate(MOCK_SELECTOR_PATH, selectorData, CreateMode.PERSISTENT);
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(subscribeList.size(), is(2));
         assertThat(subscribeList.get(0).getName(), is("test"));
     }
@@ -191,9 +191,9 @@ public final class ZookeeperSyncDataServiceTest {
                 unSubscribeList.add(selectorData);
             }
         }, Collections.emptyList(), Collections.emptyList());
-        Thread.sleep(200);
+        Thread.sleep(500);
         zkClient.delete(MOCK_SELECTOR_PATH);
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(unSubscribeList.size(), is(1));
         assertThat(unSubscribeList.get(0).getId(), is("test"));
     }
@@ -209,7 +209,7 @@ public final class ZookeeperSyncDataServiceTest {
                 subscribeList.add(data);
             }
         }, Collections.emptyList(), Collections.emptyList());
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(subscribeList.size(), is(1));
         assertThat(subscribeList.get(0).getName(), is(MOCK_RULE_NAME));
     }
@@ -225,9 +225,9 @@ public final class ZookeeperSyncDataServiceTest {
                 subscribeList.add(data);
             }
         }, Collections.emptyList(), Collections.emptyList());
-        Thread.sleep(200);
+        Thread.sleep(500);
         zkClient.createOrUpdate(MOCK_RULE_PATH, ruleData, CreateMode.PERSISTENT);
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(subscribeList.size(), is(2));
         assertThat(subscribeList.get(0).getName(), is(MOCK_RULE_NAME));
     }
@@ -243,9 +243,9 @@ public final class ZookeeperSyncDataServiceTest {
                 unSubscribeList.add(data);
             }
         }, Collections.emptyList(), Collections.emptyList());
-        Thread.sleep(200);
+        Thread.sleep(500);
         zkClient.delete(MOCK_RULE_PATH);
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(unSubscribeList.size(), is(1));
         assertThat(unSubscribeList.get(0).getSelectorId() + DefaultPathConstants.SELECTOR_JOIN_RULE + unSubscribeList.get(0).getId(), is(MOCK_RULE_NAME));
     }
@@ -267,7 +267,7 @@ public final class ZookeeperSyncDataServiceTest {
         };
         syncDataService = new ZookeeperSyncDataService(zkClient,
                 null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(subscribeList.size(), is(1));
     }
 
@@ -288,10 +288,10 @@ public final class ZookeeperSyncDataServiceTest {
         };
         syncDataService = new ZookeeperSyncDataService(zkClient,
                 null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
-        Thread.sleep(200);
+        Thread.sleep(500);
         appAuthData.setEnabled(true);
         zkClient.createOrUpdate(MOCK_APP_AUTH_PATH, appAuthData, CreateMode.PERSISTENT);
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(subscribeList.size(), is(2));
         assertTrue(subscribeList.get(1).getEnabled());
     }
@@ -313,9 +313,9 @@ public final class ZookeeperSyncDataServiceTest {
         };
         syncDataService = new ZookeeperSyncDataService(zkClient,
                 null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
-        Thread.sleep(200);
+        Thread.sleep(500);
         zkClient.delete(MOCK_APP_AUTH_PATH);
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(unSubscribeList.size(), is(1));
         assertThat(unSubscribeList.get(0).getAppKey(), is(MOCK_APP_AUTH_KEY));
     }
@@ -337,7 +337,7 @@ public final class ZookeeperSyncDataServiceTest {
         };
         syncDataService = new ZookeeperSyncDataService(zkClient,
                 null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(subscribeList.size(), is(1));
     }
 
@@ -358,10 +358,10 @@ public final class ZookeeperSyncDataServiceTest {
         };
         syncDataService = new ZookeeperSyncDataService(zkClient,
                 null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
-        Thread.sleep(200);
+        Thread.sleep(500);
         metaData.setEnabled(true);
         zkClient.createOrUpdate(MOCK_META_DATA_PATH, metaData, CreateMode.PERSISTENT);
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(subscribeList.size(), is(2));
         assertTrue(subscribeList.get(1).getEnabled());
     }
@@ -383,9 +383,9 @@ public final class ZookeeperSyncDataServiceTest {
         };
         syncDataService = new ZookeeperSyncDataService(zkClient,
                 null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
-        Thread.sleep(200);
+        Thread.sleep(500);
         zkClient.delete(MOCK_META_DATA_PATH);
-        Thread.sleep(100);
+        Thread.sleep(500);
         assertThat(unSubscribeList.size(), is(1));
         assertThat(unSubscribeList.get(0).getPath(), is(MOCK_META_DATA_ID));
     }

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/test/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/test/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java
@@ -1,386 +1,397 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//
-//package org.apache.shenyu.sync.data.zookeeper;
-//
-//import com.google.common.collect.Lists;
-//import org.I0Itec.zkclient.IZkDataListener;
-//import org.I0Itec.zkclient.ZkClient;
-//import org.apache.shenyu.common.constant.DefaultPathConstants;
-//import org.apache.shenyu.common.dto.AppAuthData;
-//import org.apache.shenyu.common.dto.MetaData;
-//import org.apache.shenyu.common.dto.PluginData;
-//import org.apache.shenyu.common.dto.RuleData;
-//import org.apache.shenyu.common.dto.SelectorData;
-//import org.apache.shenyu.common.utils.GsonUtils;
-//import org.apache.shenyu.sync.data.api.AuthDataSubscriber;
-//import org.apache.shenyu.sync.data.api.MetaDataSubscriber;
-//import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
-//import org.junit.jupiter.api.AfterEach;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//import java.util.ArrayList;
-//import java.util.Collections;
-//import java.util.List;
-//
-//import static junit.framework.TestCase.assertEquals;
-//import static junit.framework.TestCase.assertTrue;
-//import static org.hamcrest.MatcherAssert.assertThat;
-//import static org.hamcrest.core.Is.is;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//@ExtendWith(MockitoExtension.class)
-//public final class ZookeeperSyncDataServiceTest {
-//
-//    private static final String MOCK_PLUGIN_PARENT_PATH = "/shenyu/plugin";
-//
-//    private static final String MOCK_PLUGIN_PATH = "/shenyu/plugin/divide";
-//
-//    private static final String MOCK_PLUGIN_NAME = "divide";
-//
-//    private static final String MOCK_SELECTOR_PARENT_PATH = "/shenyu/selector/divide";
-//
-//    private static final String MOCK_SELECTOR_PATH = "/shenyu/selector/divide/test";
-//
-//    private static final String MOCK_SELECTOR_NAME = "test";
-//
-//    private static final String MOCK_RULE_PARENT_PATH = "/shenyu/rule/divide";
-//
-//    private static final String MOCK_RULE_PATH = "/shenyu/rule/divide/test-test";
-//
-//    private static final String MOCK_RULE_NAME = "test-test";
-//
-//    private static final String MOCK_APP_AUTH_PARENT_PATH = "/shenyu/auth";
-//
-//    private static final String MOCK_APP_AUTH_PATH = "/shenyu/auth/test";
-//
-//    private static final String MOCK_APP_AUTH_KEY = "test";
-//
-//    private static final String MOCK_META_DATA_PARENT_PATH = "/shenyu/metaData";
-//
-//    private static final String MOCK_META_DATA_PATH = "/shenyu/metaData/test";
-//
-//    private static final String MOCK_META_DATA_ID = "test";
-//
-//    private ZkClient zkClient;
-//
-//    private ZookeeperSyncDataService syncDataService;
-//
-//    @BeforeEach
-//    public void setUp() {
-//        zkClient = mock(ZkClient.class);
-//        //mock plugin data & method
-//        PluginData pluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.FALSE).build();
-//        when(zkClient.exists(anyString())).thenReturn(Boolean.FALSE);
-//        when(zkClient.readData(MOCK_PLUGIN_PATH)).thenReturn(GsonUtils.getInstance().toJson(pluginData));
-//        when(zkClient.getChildren(MOCK_PLUGIN_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_PLUGIN_NAME));
-//        //mock selector data & method
-//        SelectorData selectorData = SelectorData.builder().name(MOCK_SELECTOR_NAME).enabled(Boolean.FALSE).build();
-//        when(zkClient.readData(MOCK_SELECTOR_PATH)).thenReturn(GsonUtils.getInstance().toJson(selectorData));
-//        when(zkClient.getChildren(MOCK_SELECTOR_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_SELECTOR_NAME));
-//        //mock rule data & method
-//        RuleData ruleData = RuleData.builder().name(MOCK_RULE_NAME).enabled(Boolean.FALSE).build();
-//        when(zkClient.readData(MOCK_RULE_PATH)).thenReturn(GsonUtils.getInstance().toJson(ruleData));
-//        when(zkClient.getChildren(MOCK_RULE_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_RULE_NAME));
-//        //mock auth data & method
-//        AppAuthData appAuthData = AppAuthData.builder().appKey(MOCK_APP_AUTH_KEY).enabled(Boolean.FALSE).build();
-//        when(zkClient.readData(MOCK_APP_AUTH_PATH)).thenReturn(GsonUtils.getInstance().toJson(appAuthData));
-//        when(zkClient.getChildren(MOCK_APP_AUTH_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_APP_AUTH_KEY));
-//        //mock meta data & method
-//        MetaData metaData = MetaData.builder().id(MOCK_META_DATA_ID).enabled(Boolean.FALSE).build();
-//        when(zkClient.readData(MOCK_META_DATA_PATH)).thenReturn(GsonUtils.getInstance().toJson(metaData));
-//        when(zkClient.getChildren(MOCK_META_DATA_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_META_DATA_ID));
-//    }
-//
-//    @Test
-//    public void testWatchPluginWhenInit() {
-//        final List<PluginData> subscribeList = new ArrayList<>(1);
-//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-//            @Override
-//            public void onSubscribe(final PluginData pluginData) {
-//                subscribeList.add(pluginData);
-//            }
-//        }, Collections.emptyList(), Collections.emptyList());
-//        assertThat(subscribeList.size(), is(1));
-//        assertThat(subscribeList.get(0).getName(), is("divide"));
-//    }
-//
-//    @Test
-//    public void testWatchPluginWhenDataChange() throws Exception {
-//        final PluginData changedPluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.TRUE).build();
-//        final List<PluginData> subscribeList = new ArrayList<>(2);
-//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-//            @Override
-//            public void onSubscribe(final PluginData pluginData) {
-//                subscribeList.add(pluginData);
-//            }
-//        }, Collections.emptyList(), Collections.emptyList());
-//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-//        verify(zkClient).subscribeDataChanges(eq(MOCK_PLUGIN_PATH), captor.capture());
-//        captor.getValue().handleDataChange(MOCK_PLUGIN_PATH, GsonUtils.getInstance().toJson(changedPluginData));
-//        assertThat(subscribeList.size(), is(2));
-//        assertTrue(subscribeList.get(1).getEnabled());
-//    }
-//
-//    @Test
-//    public void testWatchPluginWhenDataDeleted() throws Exception {
-//        final List<PluginData> unSubscribeList = new ArrayList<>(1);
-//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-//            @Override
-//            public void unSubscribe(final PluginData pluginData) {
-//                unSubscribeList.add(pluginData);
-//            }
-//        }, Collections.emptyList(), Collections.emptyList());
-//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-//        verify(zkClient).subscribeDataChanges(eq(MOCK_PLUGIN_PATH), captor.capture());
-//        captor.getValue().handleDataDeleted(MOCK_PLUGIN_PATH);
-//        assertThat(unSubscribeList.size(), is(1));
-//        assertThat(unSubscribeList.get(0).getName(), is("divide"));
-//    }
-//
-//    @Test
-//    public void testWatchSelectorWhenInit() {
-//        final List<SelectorData> subscribeList = new ArrayList<>(1);
-//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-//            @Override
-//            public void onSelectorSubscribe(final SelectorData selectorData) {
-//                subscribeList.add(selectorData);
-//            }
-//        }, Collections.emptyList(), Collections.emptyList());
-//        assertThat(subscribeList.size(), is(1));
-//        assertThat(subscribeList.get(0).getName(), is("test"));
-//    }
-//
-//    @Test
-//    public void testWatchSelectorWhenDataChange() throws Exception {
-//        final SelectorData changedSelectorData = SelectorData.builder().name(MOCK_SELECTOR_NAME).enabled(Boolean.TRUE).build();
-//        final List<SelectorData> subscribeList = new ArrayList<>(2);
-//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-//            @Override
-//            public void onSelectorSubscribe(final SelectorData selectorData) {
-//                subscribeList.add(selectorData);
-//            }
-//        }, Collections.emptyList(), Collections.emptyList());
-//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-//        verify(zkClient).subscribeDataChanges(eq(MOCK_SELECTOR_PATH), captor.capture());
-//        captor.getValue().handleDataChange(MOCK_SELECTOR_PATH, GsonUtils.getInstance().toJson(changedSelectorData));
-//        assertThat(subscribeList.size(), is(2));
-//        assertTrue(subscribeList.get(1).getEnabled());
-//    }
-//
-//    @Test
-//    public void testWatchSelectorWhenDataDeleted() throws Exception {
-//        final List<SelectorData> unSubscribeList = new ArrayList<>(1);
-//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-//            @Override
-//            public void unSelectorSubscribe(final SelectorData selectorData) {
-//                unSubscribeList.add(selectorData);
-//            }
-//        }, Collections.emptyList(), Collections.emptyList());
-//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-//        verify(zkClient).subscribeDataChanges(eq(MOCK_SELECTOR_PATH), captor.capture());
-//        captor.getValue().handleDataDeleted(MOCK_SELECTOR_PATH);
-//        assertThat(unSubscribeList.size(), is(1));
-//        assertThat(unSubscribeList.get(0).getId(), is("test"));
-//    }
-//
-//    @Test
-//    public void testWatchRuleWhenInit() {
-//        final List<RuleData> subscribeList = new ArrayList<>(1);
-//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-//            @Override
-//            public void onRuleSubscribe(final RuleData ruleData) {
-//                subscribeList.add(ruleData);
-//            }
-//        }, Collections.emptyList(), Collections.emptyList());
-//        assertThat(subscribeList.size(), is(1));
-//        assertThat(subscribeList.get(0).getName(), is(MOCK_RULE_NAME));
-//    }
-//
-//    @Test
-//    public void testWatchRuleWhenDataChange() throws Exception {
-//        final RuleData changedRuleData = RuleData.builder().name(MOCK_RULE_NAME).enabled(Boolean.TRUE).build();
-//        final List<RuleData> subscribeList = new ArrayList<>(2);
-//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-//            @Override
-//            public void onRuleSubscribe(final RuleData ruleData) {
-//                subscribeList.add(ruleData);
-//            }
-//        }, Collections.emptyList(), Collections.emptyList());
-//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-//        verify(zkClient).subscribeDataChanges(eq(MOCK_RULE_PATH), captor.capture());
-//        captor.getValue().handleDataChange(MOCK_RULE_PATH, GsonUtils.getInstance().toJson(changedRuleData));
-//        assertThat(subscribeList.size(), is(2));
-//        assertTrue(subscribeList.get(1).getEnabled());
-//    }
-//
-//    @Test
-//    public void testWatchRuleWhenDataDeleted() throws Exception {
-//        final List<RuleData> unSubscribeList = new ArrayList<>(1);
-//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-//            @Override
-//            public void unRuleSubscribe(final RuleData ruleData) {
-//                unSubscribeList.add(ruleData);
-//            }
-//        }, Collections.emptyList(), Collections.emptyList());
-//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-//        verify(zkClient).subscribeDataChanges(eq(MOCK_RULE_PATH), captor.capture());
-//        captor.getValue().handleDataDeleted(MOCK_RULE_PATH);
-//        assertThat(unSubscribeList.size(), is(1));
-//        assertThat(unSubscribeList.get(0).getSelectorId() + DefaultPathConstants.SELECTOR_JOIN_RULE + unSubscribeList.get(0).getId(), is(MOCK_RULE_NAME));
-//    }
-//
-//    @Test
-//    public void testWatchAppAuthWhenInit() {
-//        final List<AppAuthData> subscribeList = new ArrayList<>(1);
-//        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
-//            @Override
-//            public void onSubscribe(final AppAuthData appAuthData) {
-//                subscribeList.add(appAuthData);
-//            }
-//
-//            @Override
-//            public void unSubscribe(final AppAuthData appAuthData) {
-//            }
-//        };
-//        syncDataService = new ZookeeperSyncDataService(zkClient,
-//                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
-//        assertThat(subscribeList.size(), is(1));
-//    }
-//
-//    @Test
-//    public void testWatchAppAuthWhenDataChange() throws Exception {
-//        final AppAuthData changedAppAuthData = AppAuthData.builder().appKey("test").enabled(Boolean.TRUE).build();
-//        final List<AppAuthData> subscribeList = new ArrayList<>(1);
-//        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
-//            @Override
-//            public void onSubscribe(final AppAuthData appAuthData) {
-//                subscribeList.add(appAuthData);
-//            }
-//
-//            @Override
-//            public void unSubscribe(final AppAuthData appAuthData) {
-//            }
-//        };
-//        syncDataService = new ZookeeperSyncDataService(zkClient,
-//                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
-//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-//        verify(zkClient).subscribeDataChanges(eq(MOCK_APP_AUTH_PATH), captor.capture());
-//        captor.getValue().handleDataChange(MOCK_APP_AUTH_PATH, GsonUtils.getInstance().toJson(changedAppAuthData));
-//        assertThat(subscribeList.size(), is(2));
-//        assertTrue(subscribeList.get(1).getEnabled());
-//    }
-//
-//    @Test
-//    public void testWatchAppAuthWhenDataDeleted() throws Exception {
-//        final List<AppAuthData> unSubscribeList = new ArrayList<>(1);
-//        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
-//            @Override
-//            public void onSubscribe(final AppAuthData appAuthData) {
-//            }
-//
-//            @Override
-//            public void unSubscribe(final AppAuthData appAuthData) {
-//                unSubscribeList.add(appAuthData);
-//            }
-//        };
-//        syncDataService = new ZookeeperSyncDataService(zkClient,
-//                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
-//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-//        verify(zkClient).subscribeDataChanges(eq(MOCK_APP_AUTH_PATH), captor.capture());
-//        captor.getValue().handleDataDeleted(MOCK_APP_AUTH_PATH);
-//        assertThat(unSubscribeList.size(), is(1));
-//        assertThat(unSubscribeList.get(0).getAppKey(), is(MOCK_APP_AUTH_KEY));
-//    }
-//
-//    @Test
-//    public void testWatchMetaDataWhenInit() {
-//        final List<MetaData> subscribeList = new ArrayList<>(1);
-//        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
-//            @Override
-//            public void onSubscribe(final MetaData metaData) {
-//                subscribeList.add(metaData);
-//            }
-//
-//            @Override
-//            public void unSubscribe(final MetaData metaData) {
-//            }
-//        };
-//        syncDataService = new ZookeeperSyncDataService(zkClient,
-//                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
-//        assertThat(subscribeList.size(), is(1));
-//    }
-//
-//    @Test
-//    public void testWatchMetaDataWhenDataChange() throws Exception {
-//        final MetaData changedMetaData = MetaData.builder().id(MOCK_META_DATA_ID).enabled(Boolean.TRUE).build();
-//        final List<MetaData> subscribeList = new ArrayList<>(2);
-//        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
-//            @Override
-//            public void onSubscribe(final MetaData metaData) {
-//                subscribeList.add(metaData);
-//            }
-//
-//            @Override
-//            public void unSubscribe(final MetaData metaData) {
-//            }
-//        };
-//        syncDataService = new ZookeeperSyncDataService(zkClient,
-//                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
-//        assertEquals(1, subscribeList.size());
-//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-//        verify(zkClient).subscribeDataChanges(eq(MOCK_META_DATA_PATH), captor.capture());
-//        captor.getValue().handleDataChange(MOCK_META_DATA_PATH, GsonUtils.getInstance().toJson(changedMetaData));
-//        assertThat(subscribeList.size(), is(2));
-//        assertTrue(subscribeList.get(1).getEnabled());
-//    }
-//
-//    @Test
-//    public void testWatchMetaDataWhenDataDeleted() throws Exception {
-//        final List<MetaData> unSubscribeList = new ArrayList<>(1);
-//        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
-//            @Override
-//            public void onSubscribe(final MetaData metaData) {
-//            }
-//
-//            @Override
-//            public void unSubscribe(final MetaData metaData) {
-//                unSubscribeList.add(metaData);
-//            }
-//        };
-//        syncDataService = new ZookeeperSyncDataService(zkClient,
-//                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
-//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-//        verify(zkClient).subscribeDataChanges(eq(MOCK_META_DATA_PATH), captor.capture());
-//        captor.getValue().handleDataDeleted(MOCK_META_DATA_PATH);
-//        assertThat(unSubscribeList.size(), is(1));
-//        assertThat(unSubscribeList.get(0).getPath(), is(MOCK_META_DATA_ID));
-//    }
-//
-//    @AfterEach
-//    public void tearDown() {
-//        syncDataService.close();
-//    }
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.sync.data.zookeeper;
+
+import com.google.common.collect.Lists;
+import org.apache.curator.test.TestingServer;
+import org.apache.shenyu.common.constant.DefaultPathConstants;
+import org.apache.shenyu.common.dto.AppAuthData;
+import org.apache.shenyu.common.dto.MetaData;
+import org.apache.shenyu.common.dto.PluginData;
+import org.apache.shenyu.common.dto.RuleData;
+import org.apache.shenyu.common.dto.SelectorData;
+import org.apache.shenyu.sync.data.api.AuthDataSubscriber;
+import org.apache.shenyu.sync.data.api.MetaDataSubscriber;
+import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
+import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+public final class ZookeeperSyncDataServiceTest {
+
+    private static final String MOCK_PLUGIN_PARENT_PATH = "/shenyu/plugin";
+
+    private static final String MOCK_PLUGIN_PATH = "/shenyu/plugin/divide";
+
+    private static final String MOCK_PLUGIN_NAME = "divide";
+
+    private static final String MOCK_SELECTOR_PARENT_PATH = "/shenyu/selector/divide";
+
+    private static final String MOCK_SELECTOR_PATH = "/shenyu/selector/divide/test";
+
+    private static final String MOCK_SELECTOR_NAME = "test";
+
+    private static final String MOCK_RULE_PARENT_PATH = "/shenyu/rule/divide";
+
+    private static final String MOCK_RULE_PATH = "/shenyu/rule/divide/test-test";
+
+    private static final String MOCK_RULE_NAME = "test-test";
+
+    private static final String MOCK_APP_AUTH_PARENT_PATH = "/shenyu/auth";
+
+    private static final String MOCK_APP_AUTH_PATH = "/shenyu/auth/test";
+
+    private static final String MOCK_APP_AUTH_KEY = "test";
+
+    private static final String MOCK_META_DATA_PARENT_PATH = "/shenyu/metaData";
+
+    private static final String MOCK_META_DATA_PATH = "/shenyu/metaData/test";
+
+    private static final String MOCK_META_DATA_ID = "test";
+
+    private ZookeeperClient zkClient;
+
+    private ZookeeperSyncDataService syncDataService;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        zkClient = mock(ZookeeperClient.class);
+        TestingServer server = new TestingServer();
+        ZookeeperConfig config = new ZookeeperConfig(server.getConnectString());
+        zkClient = new ZookeeperClient(config);
+        zkClient.start();
+    }
+
+    @Test
+    public void testWatchPluginWhenInit() throws InterruptedException {
+        final List<PluginData> subscribeList = new ArrayList<>(1);
+        PluginData pluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_PLUGIN_PATH, pluginData, CreateMode.PERSISTENT);
+
+        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+            @Override
+            public void onSubscribe(final PluginData pluginData) {
+                subscribeList.add(pluginData);
+            }
+        }, Collections.emptyList(), Collections.emptyList());
+        // wait for listener taking action
+        Thread.sleep(100);
+        assertThat(subscribeList.size(), is(1));
+        assertThat(subscribeList.get(0).getName(), is("divide"));
+    }
+
+    @Test
+    public void testWatchPluginWhenDataChange() throws Exception {
+        final List<PluginData> subscribeList = new ArrayList<>(1);
+        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+            @Override
+            public void onSubscribe(final PluginData pluginData) {
+                subscribeList.add(pluginData);
+            }
+        }, Collections.emptyList(), Collections.emptyList());
+
+        PluginData pluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_PLUGIN_PATH, pluginData, CreateMode.PERSISTENT);
+        // wait for listener taking action
+        Thread.sleep(100);
+        assertThat(subscribeList.size(), is(1));
+        assertThat(subscribeList.get(0).getName(), is("divide"));
+    }
+
+    @Test
+    public void testWatchPluginWhenDataDeleted() throws Exception {
+        final List<PluginData> unSubscribeList = new ArrayList<>(1);
+        PluginData pluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_PLUGIN_PATH, pluginData, CreateMode.PERSISTENT);
+
+        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+            @Override
+            public void unSubscribe(final PluginData pluginData) {
+                unSubscribeList.add(pluginData);
+            }
+        }, Collections.emptyList(), Collections.emptyList());
+        Thread.sleep(200);
+        zkClient.delete(MOCK_PLUGIN_PATH);
+        // wait for listener taking action
+        Thread.sleep(100);
+        assertThat(unSubscribeList.size(), is(1));
+        assertThat(unSubscribeList.get(0).getName(), is("divide"));
+    }
+
+    @Test
+    public void testWatchSelectorWhenInit() throws InterruptedException {
+        final List<SelectorData> subscribeList = new ArrayList<>(1);
+        SelectorData selectorData = SelectorData.builder().name(MOCK_SELECTOR_NAME).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_SELECTOR_PATH, selectorData, CreateMode.PERSISTENT);
+        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+            @Override
+            public void onSelectorSubscribe(final SelectorData selectorData) {
+                subscribeList.add(selectorData);
+            }
+        }, Collections.emptyList(), Collections.emptyList());
+        Thread.sleep(100);
+        assertThat(subscribeList.size(), is(1));
+        assertThat(subscribeList.get(0).getName(), is("test"));
+    }
+
+    @Test
+    public void testWatchSelectorWhenDataChange() throws Exception {
+        final List<SelectorData> subscribeList = new ArrayList<>(1);
+        SelectorData selectorData = SelectorData.builder().name(MOCK_SELECTOR_NAME).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_SELECTOR_PATH, selectorData, CreateMode.PERSISTENT);
+        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+            @Override
+            public void onSelectorSubscribe(final SelectorData selectorData) {
+                subscribeList.add(selectorData);
+            }
+        }, Collections.emptyList(), Collections.emptyList());
+        Thread.sleep(200);
+        zkClient.createOrUpdate(MOCK_SELECTOR_PATH, selectorData, CreateMode.PERSISTENT);
+        Thread.sleep(100);
+        assertThat(subscribeList.size(), is(2));
+        assertThat(subscribeList.get(0).getName(), is("test"));
+    }
+
+    @Test
+    public void testWatchSelectorWhenDataDeleted() throws Exception {
+        final List<SelectorData> unSubscribeList = new ArrayList<>(1);
+        SelectorData selectorData = SelectorData.builder().name(MOCK_SELECTOR_NAME).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_SELECTOR_PATH, selectorData, CreateMode.PERSISTENT);
+        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+            @Override
+            public void unSelectorSubscribe(final SelectorData selectorData) {
+                unSubscribeList.add(selectorData);
+            }
+        }, Collections.emptyList(), Collections.emptyList());
+        Thread.sleep(200);
+        zkClient.delete(MOCK_SELECTOR_PATH);
+        Thread.sleep(100);
+        assertThat(unSubscribeList.size(), is(1));
+        assertThat(unSubscribeList.get(0).getId(), is("test"));
+    }
+
+    @Test
+    public void testWatchRuleWhenInit() throws InterruptedException {
+        final List<RuleData> subscribeList = new ArrayList<>(1);
+        RuleData ruleData = RuleData.builder().name(MOCK_RULE_NAME).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_RULE_PATH, ruleData, CreateMode.PERSISTENT);
+        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+            @Override
+            public void onRuleSubscribe(final RuleData data) {
+                subscribeList.add(data);
+            }
+        }, Collections.emptyList(), Collections.emptyList());
+        Thread.sleep(100);
+        assertThat(subscribeList.size(), is(1));
+        assertThat(subscribeList.get(0).getName(), is(MOCK_RULE_NAME));
+    }
+
+    @Test
+    public void testWatchRuleWhenDataChange() throws Exception {
+        final List<RuleData> subscribeList = new ArrayList<>(1);
+        RuleData ruleData = RuleData.builder().name(MOCK_RULE_NAME).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_RULE_PATH, ruleData, CreateMode.PERSISTENT);
+        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+            @Override
+            public void onRuleSubscribe(final RuleData data) {
+                subscribeList.add(data);
+            }
+        }, Collections.emptyList(), Collections.emptyList());
+        Thread.sleep(200);
+        zkClient.createOrUpdate(MOCK_RULE_PATH, ruleData, CreateMode.PERSISTENT);
+        Thread.sleep(100);
+        assertThat(subscribeList.size(), is(2));
+        assertThat(subscribeList.get(0).getName(), is(MOCK_RULE_NAME));
+    }
+
+    @Test
+    public void testWatchRuleWhenDataDeleted() throws Exception {
+        final List<RuleData> unSubscribeList = new ArrayList<>(1);
+        RuleData ruleData = RuleData.builder().name(MOCK_RULE_NAME).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_RULE_PATH, ruleData, CreateMode.PERSISTENT);
+        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+            @Override
+            public void unRuleSubscribe(final RuleData data) {
+                unSubscribeList.add(data);
+            }
+        }, Collections.emptyList(), Collections.emptyList());
+        Thread.sleep(200);
+        zkClient.delete(MOCK_RULE_PATH);
+        Thread.sleep(100);
+        assertThat(unSubscribeList.size(), is(1));
+        assertThat(unSubscribeList.get(0).getSelectorId() + DefaultPathConstants.SELECTOR_JOIN_RULE + unSubscribeList.get(0).getId(), is(MOCK_RULE_NAME));
+    }
+
+    @Test
+    public void testWatchAppAuthWhenInit() throws InterruptedException {
+        final List<AppAuthData> subscribeList = new ArrayList<>(1);
+        AppAuthData appAuthData = AppAuthData.builder().appKey(MOCK_APP_AUTH_KEY).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_APP_AUTH_PATH, appAuthData, CreateMode.PERSISTENT);
+        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
+            @Override
+            public void onSubscribe(final AppAuthData appAuthData) {
+                subscribeList.add(appAuthData);
+            }
+
+            @Override
+            public void unSubscribe(final AppAuthData appAuthData) {
+            }
+        };
+        syncDataService = new ZookeeperSyncDataService(zkClient,
+                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
+        Thread.sleep(100);
+        assertThat(subscribeList.size(), is(1));
+    }
+
+    @Test
+    public void testWatchAppAuthWhenDataChange() throws Exception {
+        final List<AppAuthData> subscribeList = new ArrayList<>(1);
+        AppAuthData appAuthData = AppAuthData.builder().appKey(MOCK_APP_AUTH_KEY).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_APP_AUTH_PATH, appAuthData, CreateMode.PERSISTENT);
+        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
+            @Override
+            public void onSubscribe(final AppAuthData appAuthData) {
+                subscribeList.add(appAuthData);
+            }
+
+            @Override
+            public void unSubscribe(final AppAuthData appAuthData) {
+            }
+        };
+        syncDataService = new ZookeeperSyncDataService(zkClient,
+                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
+        Thread.sleep(200);
+        appAuthData.setEnabled(true);
+        zkClient.createOrUpdate(MOCK_APP_AUTH_PATH, appAuthData, CreateMode.PERSISTENT);
+        Thread.sleep(100);
+        assertThat(subscribeList.size(), is(2));
+        assertTrue(subscribeList.get(1).getEnabled());
+    }
+
+    @Test
+    public void testWatchAppAuthWhenDataDeleted() throws Exception {
+        final List<AppAuthData> unSubscribeList = new ArrayList<>(1);
+        AppAuthData appAuthData = AppAuthData.builder().appKey(MOCK_APP_AUTH_KEY).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_APP_AUTH_PATH, appAuthData, CreateMode.PERSISTENT);
+        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
+            @Override
+            public void onSubscribe(final AppAuthData appAuthData) {
+            }
+
+            @Override
+            public void unSubscribe(final AppAuthData appAuthData) {
+                unSubscribeList.add(appAuthData);
+            }
+        };
+        syncDataService = new ZookeeperSyncDataService(zkClient,
+                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
+        Thread.sleep(200);
+        zkClient.delete(MOCK_APP_AUTH_PATH);
+        Thread.sleep(100);
+        assertThat(unSubscribeList.size(), is(1));
+        assertThat(unSubscribeList.get(0).getAppKey(), is(MOCK_APP_AUTH_KEY));
+    }
+
+    @Test
+    public void testWatchMetaDataWhenInit() throws InterruptedException {
+        final List<MetaData> subscribeList = new ArrayList<>(1);
+        MetaData metaData = MetaData.builder().id(MOCK_META_DATA_ID).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_META_DATA_PATH, metaData, CreateMode.PERSISTENT);
+        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
+            @Override
+            public void onSubscribe(final MetaData metaData) {
+                subscribeList.add(metaData);
+            }
+
+            @Override
+            public void unSubscribe(final MetaData metaData) {
+            }
+        };
+        syncDataService = new ZookeeperSyncDataService(zkClient,
+                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
+        Thread.sleep(100);
+        assertThat(subscribeList.size(), is(1));
+    }
+
+    @Test
+    public void testWatchMetaDataWhenDataChange() throws Exception {
+        final List<MetaData> subscribeList = new ArrayList<>(1);
+        MetaData metaData = MetaData.builder().id(MOCK_META_DATA_ID).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_META_DATA_PATH, metaData, CreateMode.PERSISTENT);
+        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
+            @Override
+            public void onSubscribe(final MetaData metaData) {
+                subscribeList.add(metaData);
+            }
+
+            @Override
+            public void unSubscribe(final MetaData metaData) {
+            }
+        };
+        syncDataService = new ZookeeperSyncDataService(zkClient,
+                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
+        Thread.sleep(200);
+        metaData.setEnabled(true);
+        zkClient.createOrUpdate(MOCK_META_DATA_PATH, metaData, CreateMode.PERSISTENT);
+        Thread.sleep(100);
+        assertThat(subscribeList.size(), is(2));
+        assertTrue(subscribeList.get(1).getEnabled());
+    }
+
+    @Test
+    public void testWatchMetaDataWhenDataDeleted() throws Exception {
+        final List<MetaData> unSubscribeList = new ArrayList<>(1);
+        MetaData metaData = MetaData.builder().id(MOCK_META_DATA_ID).enabled(Boolean.FALSE).build();
+        zkClient.createOrUpdate(MOCK_META_DATA_PATH, metaData, CreateMode.PERSISTENT);
+        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
+            @Override
+            public void onSubscribe(final MetaData metaData) {
+            }
+
+            @Override
+            public void unSubscribe(final MetaData metaData) {
+                unSubscribeList.add(metaData);
+            }
+        };
+        syncDataService = new ZookeeperSyncDataService(zkClient,
+                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
+        Thread.sleep(200);
+        zkClient.delete(MOCK_META_DATA_PATH);
+        Thread.sleep(100);
+        assertThat(unSubscribeList.size(), is(1));
+        assertThat(unSubscribeList.get(0).getPath(), is(MOCK_META_DATA_ID));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        syncDataService.close();
+    }
+}

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/test/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/test/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java
@@ -1,386 +1,386 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package org.apache.shenyu.sync.data.zookeeper;
-
-import com.google.common.collect.Lists;
-import org.I0Itec.zkclient.IZkDataListener;
-import org.I0Itec.zkclient.ZkClient;
-import org.apache.shenyu.common.constant.DefaultPathConstants;
-import org.apache.shenyu.common.dto.AppAuthData;
-import org.apache.shenyu.common.dto.MetaData;
-import org.apache.shenyu.common.dto.PluginData;
-import org.apache.shenyu.common.dto.RuleData;
-import org.apache.shenyu.common.dto.SelectorData;
-import org.apache.shenyu.common.utils.GsonUtils;
-import org.apache.shenyu.sync.data.api.AuthDataSubscriber;
-import org.apache.shenyu.sync.data.api.MetaDataSubscriber;
-import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-@ExtendWith(MockitoExtension.class)
-public final class ZookeeperSyncDataServiceTest {
-
-    private static final String MOCK_PLUGIN_PARENT_PATH = "/shenyu/plugin";
-
-    private static final String MOCK_PLUGIN_PATH = "/shenyu/plugin/divide";
-
-    private static final String MOCK_PLUGIN_NAME = "divide";
-
-    private static final String MOCK_SELECTOR_PARENT_PATH = "/shenyu/selector/divide";
-
-    private static final String MOCK_SELECTOR_PATH = "/shenyu/selector/divide/test";
-
-    private static final String MOCK_SELECTOR_NAME = "test";
-
-    private static final String MOCK_RULE_PARENT_PATH = "/shenyu/rule/divide";
-
-    private static final String MOCK_RULE_PATH = "/shenyu/rule/divide/test-test";
-
-    private static final String MOCK_RULE_NAME = "test-test";
-
-    private static final String MOCK_APP_AUTH_PARENT_PATH = "/shenyu/auth";
-
-    private static final String MOCK_APP_AUTH_PATH = "/shenyu/auth/test";
-
-    private static final String MOCK_APP_AUTH_KEY = "test";
-
-    private static final String MOCK_META_DATA_PARENT_PATH = "/shenyu/metaData";
-
-    private static final String MOCK_META_DATA_PATH = "/shenyu/metaData/test";
-
-    private static final String MOCK_META_DATA_ID = "test";
-
-    private ZkClient zkClient;
-
-    private ZookeeperSyncDataService syncDataService;
-
-    @BeforeEach
-    public void setUp() {
-        zkClient = mock(ZkClient.class);
-        //mock plugin data & method
-        PluginData pluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.FALSE).build();
-        when(zkClient.exists(anyString())).thenReturn(Boolean.FALSE);
-        when(zkClient.readData(MOCK_PLUGIN_PATH)).thenReturn(GsonUtils.getInstance().toJson(pluginData));
-        when(zkClient.getChildren(MOCK_PLUGIN_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_PLUGIN_NAME));
-        //mock selector data & method
-        SelectorData selectorData = SelectorData.builder().name(MOCK_SELECTOR_NAME).enabled(Boolean.FALSE).build();
-        when(zkClient.readData(MOCK_SELECTOR_PATH)).thenReturn(GsonUtils.getInstance().toJson(selectorData));
-        when(zkClient.getChildren(MOCK_SELECTOR_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_SELECTOR_NAME));
-        //mock rule data & method
-        RuleData ruleData = RuleData.builder().name(MOCK_RULE_NAME).enabled(Boolean.FALSE).build();
-        when(zkClient.readData(MOCK_RULE_PATH)).thenReturn(GsonUtils.getInstance().toJson(ruleData));
-        when(zkClient.getChildren(MOCK_RULE_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_RULE_NAME));
-        //mock auth data & method
-        AppAuthData appAuthData = AppAuthData.builder().appKey(MOCK_APP_AUTH_KEY).enabled(Boolean.FALSE).build();
-        when(zkClient.readData(MOCK_APP_AUTH_PATH)).thenReturn(GsonUtils.getInstance().toJson(appAuthData));
-        when(zkClient.getChildren(MOCK_APP_AUTH_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_APP_AUTH_KEY));
-        //mock meta data & method
-        MetaData metaData = MetaData.builder().id(MOCK_META_DATA_ID).enabled(Boolean.FALSE).build();
-        when(zkClient.readData(MOCK_META_DATA_PATH)).thenReturn(GsonUtils.getInstance().toJson(metaData));
-        when(zkClient.getChildren(MOCK_META_DATA_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_META_DATA_ID));
-    }
-
-    @Test
-    public void testWatchPluginWhenInit() {
-        final List<PluginData> subscribeList = new ArrayList<>(1);
-        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-            @Override
-            public void onSubscribe(final PluginData pluginData) {
-                subscribeList.add(pluginData);
-            }
-        }, Collections.emptyList(), Collections.emptyList());
-        assertThat(subscribeList.size(), is(1));
-        assertThat(subscribeList.get(0).getName(), is("divide"));
-    }
-
-    @Test
-    public void testWatchPluginWhenDataChange() throws Exception {
-        final PluginData changedPluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.TRUE).build();
-        final List<PluginData> subscribeList = new ArrayList<>(2);
-        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-            @Override
-            public void onSubscribe(final PluginData pluginData) {
-                subscribeList.add(pluginData);
-            }
-        }, Collections.emptyList(), Collections.emptyList());
-        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-        verify(zkClient).subscribeDataChanges(eq(MOCK_PLUGIN_PATH), captor.capture());
-        captor.getValue().handleDataChange(MOCK_PLUGIN_PATH, GsonUtils.getInstance().toJson(changedPluginData));
-        assertThat(subscribeList.size(), is(2));
-        assertTrue(subscribeList.get(1).getEnabled());
-    }
-
-    @Test
-    public void testWatchPluginWhenDataDeleted() throws Exception {
-        final List<PluginData> unSubscribeList = new ArrayList<>(1);
-        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-            @Override
-            public void unSubscribe(final PluginData pluginData) {
-                unSubscribeList.add(pluginData);
-            }
-        }, Collections.emptyList(), Collections.emptyList());
-        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-        verify(zkClient).subscribeDataChanges(eq(MOCK_PLUGIN_PATH), captor.capture());
-        captor.getValue().handleDataDeleted(MOCK_PLUGIN_PATH);
-        assertThat(unSubscribeList.size(), is(1));
-        assertThat(unSubscribeList.get(0).getName(), is("divide"));
-    }
-
-    @Test
-    public void testWatchSelectorWhenInit() {
-        final List<SelectorData> subscribeList = new ArrayList<>(1);
-        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-            @Override
-            public void onSelectorSubscribe(final SelectorData selectorData) {
-                subscribeList.add(selectorData);
-            }
-        }, Collections.emptyList(), Collections.emptyList());
-        assertThat(subscribeList.size(), is(1));
-        assertThat(subscribeList.get(0).getName(), is("test"));
-    }
-
-    @Test
-    public void testWatchSelectorWhenDataChange() throws Exception {
-        final SelectorData changedSelectorData = SelectorData.builder().name(MOCK_SELECTOR_NAME).enabled(Boolean.TRUE).build();
-        final List<SelectorData> subscribeList = new ArrayList<>(2);
-        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-            @Override
-            public void onSelectorSubscribe(final SelectorData selectorData) {
-                subscribeList.add(selectorData);
-            }
-        }, Collections.emptyList(), Collections.emptyList());
-        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-        verify(zkClient).subscribeDataChanges(eq(MOCK_SELECTOR_PATH), captor.capture());
-        captor.getValue().handleDataChange(MOCK_SELECTOR_PATH, GsonUtils.getInstance().toJson(changedSelectorData));
-        assertThat(subscribeList.size(), is(2));
-        assertTrue(subscribeList.get(1).getEnabled());
-    }
-
-    @Test
-    public void testWatchSelectorWhenDataDeleted() throws Exception {
-        final List<SelectorData> unSubscribeList = new ArrayList<>(1);
-        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-            @Override
-            public void unSelectorSubscribe(final SelectorData selectorData) {
-                unSubscribeList.add(selectorData);
-            }
-        }, Collections.emptyList(), Collections.emptyList());
-        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-        verify(zkClient).subscribeDataChanges(eq(MOCK_SELECTOR_PATH), captor.capture());
-        captor.getValue().handleDataDeleted(MOCK_SELECTOR_PATH);
-        assertThat(unSubscribeList.size(), is(1));
-        assertThat(unSubscribeList.get(0).getId(), is("test"));
-    }
-
-    @Test
-    public void testWatchRuleWhenInit() {
-        final List<RuleData> subscribeList = new ArrayList<>(1);
-        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-            @Override
-            public void onRuleSubscribe(final RuleData ruleData) {
-                subscribeList.add(ruleData);
-            }
-        }, Collections.emptyList(), Collections.emptyList());
-        assertThat(subscribeList.size(), is(1));
-        assertThat(subscribeList.get(0).getName(), is(MOCK_RULE_NAME));
-    }
-
-    @Test
-    public void testWatchRuleWhenDataChange() throws Exception {
-        final RuleData changedRuleData = RuleData.builder().name(MOCK_RULE_NAME).enabled(Boolean.TRUE).build();
-        final List<RuleData> subscribeList = new ArrayList<>(2);
-        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-            @Override
-            public void onRuleSubscribe(final RuleData ruleData) {
-                subscribeList.add(ruleData);
-            }
-        }, Collections.emptyList(), Collections.emptyList());
-        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-        verify(zkClient).subscribeDataChanges(eq(MOCK_RULE_PATH), captor.capture());
-        captor.getValue().handleDataChange(MOCK_RULE_PATH, GsonUtils.getInstance().toJson(changedRuleData));
-        assertThat(subscribeList.size(), is(2));
-        assertTrue(subscribeList.get(1).getEnabled());
-    }
-
-    @Test
-    public void testWatchRuleWhenDataDeleted() throws Exception {
-        final List<RuleData> unSubscribeList = new ArrayList<>(1);
-        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
-            @Override
-            public void unRuleSubscribe(final RuleData ruleData) {
-                unSubscribeList.add(ruleData);
-            }
-        }, Collections.emptyList(), Collections.emptyList());
-        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-        verify(zkClient).subscribeDataChanges(eq(MOCK_RULE_PATH), captor.capture());
-        captor.getValue().handleDataDeleted(MOCK_RULE_PATH);
-        assertThat(unSubscribeList.size(), is(1));
-        assertThat(unSubscribeList.get(0).getSelectorId() + DefaultPathConstants.SELECTOR_JOIN_RULE + unSubscribeList.get(0).getId(), is(MOCK_RULE_NAME));
-    }
-
-    @Test
-    public void testWatchAppAuthWhenInit() {
-        final List<AppAuthData> subscribeList = new ArrayList<>(1);
-        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
-            @Override
-            public void onSubscribe(final AppAuthData appAuthData) {
-                subscribeList.add(appAuthData);
-            }
-
-            @Override
-            public void unSubscribe(final AppAuthData appAuthData) {
-            }
-        };
-        syncDataService = new ZookeeperSyncDataService(zkClient,
-                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
-        assertThat(subscribeList.size(), is(1));
-    }
-
-    @Test
-    public void testWatchAppAuthWhenDataChange() throws Exception {
-        final AppAuthData changedAppAuthData = AppAuthData.builder().appKey("test").enabled(Boolean.TRUE).build();
-        final List<AppAuthData> subscribeList = new ArrayList<>(1);
-        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
-            @Override
-            public void onSubscribe(final AppAuthData appAuthData) {
-                subscribeList.add(appAuthData);
-            }
-
-            @Override
-            public void unSubscribe(final AppAuthData appAuthData) {
-            }
-        };
-        syncDataService = new ZookeeperSyncDataService(zkClient,
-                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
-        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-        verify(zkClient).subscribeDataChanges(eq(MOCK_APP_AUTH_PATH), captor.capture());
-        captor.getValue().handleDataChange(MOCK_APP_AUTH_PATH, GsonUtils.getInstance().toJson(changedAppAuthData));
-        assertThat(subscribeList.size(), is(2));
-        assertTrue(subscribeList.get(1).getEnabled());
-    }
-
-    @Test
-    public void testWatchAppAuthWhenDataDeleted() throws Exception {
-        final List<AppAuthData> unSubscribeList = new ArrayList<>(1);
-        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
-            @Override
-            public void onSubscribe(final AppAuthData appAuthData) {
-            }
-
-            @Override
-            public void unSubscribe(final AppAuthData appAuthData) {
-                unSubscribeList.add(appAuthData);
-            }
-        };
-        syncDataService = new ZookeeperSyncDataService(zkClient,
-                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
-        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-        verify(zkClient).subscribeDataChanges(eq(MOCK_APP_AUTH_PATH), captor.capture());
-        captor.getValue().handleDataDeleted(MOCK_APP_AUTH_PATH);
-        assertThat(unSubscribeList.size(), is(1));
-        assertThat(unSubscribeList.get(0).getAppKey(), is(MOCK_APP_AUTH_KEY));
-    }
-
-    @Test
-    public void testWatchMetaDataWhenInit() {
-        final List<MetaData> subscribeList = new ArrayList<>(1);
-        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
-            @Override
-            public void onSubscribe(final MetaData metaData) {
-                subscribeList.add(metaData);
-            }
-
-            @Override
-            public void unSubscribe(final MetaData metaData) {
-            }
-        };
-        syncDataService = new ZookeeperSyncDataService(zkClient,
-                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
-        assertThat(subscribeList.size(), is(1));
-    }
-
-    @Test
-    public void testWatchMetaDataWhenDataChange() throws Exception {
-        final MetaData changedMetaData = MetaData.builder().id(MOCK_META_DATA_ID).enabled(Boolean.TRUE).build();
-        final List<MetaData> subscribeList = new ArrayList<>(2);
-        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
-            @Override
-            public void onSubscribe(final MetaData metaData) {
-                subscribeList.add(metaData);
-            }
-
-            @Override
-            public void unSubscribe(final MetaData metaData) {
-            }
-        };
-        syncDataService = new ZookeeperSyncDataService(zkClient,
-                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
-        assertEquals(1, subscribeList.size());
-        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-        verify(zkClient).subscribeDataChanges(eq(MOCK_META_DATA_PATH), captor.capture());
-        captor.getValue().handleDataChange(MOCK_META_DATA_PATH, GsonUtils.getInstance().toJson(changedMetaData));
-        assertThat(subscribeList.size(), is(2));
-        assertTrue(subscribeList.get(1).getEnabled());
-    }
-
-    @Test
-    public void testWatchMetaDataWhenDataDeleted() throws Exception {
-        final List<MetaData> unSubscribeList = new ArrayList<>(1);
-        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
-            @Override
-            public void onSubscribe(final MetaData metaData) {
-            }
-
-            @Override
-            public void unSubscribe(final MetaData metaData) {
-                unSubscribeList.add(metaData);
-            }
-        };
-        syncDataService = new ZookeeperSyncDataService(zkClient,
-                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
-        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
-        verify(zkClient).subscribeDataChanges(eq(MOCK_META_DATA_PATH), captor.capture());
-        captor.getValue().handleDataDeleted(MOCK_META_DATA_PATH);
-        assertThat(unSubscribeList.size(), is(1));
-        assertThat(unSubscribeList.get(0).getPath(), is(MOCK_META_DATA_ID));
-    }
-
-    @AfterEach
-    public void tearDown() {
-        syncDataService.close();
-    }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one or more
+// * contributor license agreements.  See the NOTICE file distributed with
+// * this work for additional information regarding copyright ownership.
+// * The ASF licenses this file to You under the Apache License, Version 2.0
+// * (the "License"); you may not use this file except in compliance with
+// * the License.  You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package org.apache.shenyu.sync.data.zookeeper;
+//
+//import com.google.common.collect.Lists;
+//import org.I0Itec.zkclient.IZkDataListener;
+//import org.I0Itec.zkclient.ZkClient;
+//import org.apache.shenyu.common.constant.DefaultPathConstants;
+//import org.apache.shenyu.common.dto.AppAuthData;
+//import org.apache.shenyu.common.dto.MetaData;
+//import org.apache.shenyu.common.dto.PluginData;
+//import org.apache.shenyu.common.dto.RuleData;
+//import org.apache.shenyu.common.dto.SelectorData;
+//import org.apache.shenyu.common.utils.GsonUtils;
+//import org.apache.shenyu.sync.data.api.AuthDataSubscriber;
+//import org.apache.shenyu.sync.data.api.MetaDataSubscriber;
+//import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
+//import org.junit.jupiter.api.AfterEach;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//
+//import java.util.ArrayList;
+//import java.util.Collections;
+//import java.util.List;
+//
+//import static junit.framework.TestCase.assertEquals;
+//import static junit.framework.TestCase.assertTrue;
+//import static org.hamcrest.MatcherAssert.assertThat;
+//import static org.hamcrest.core.Is.is;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//
+//@ExtendWith(MockitoExtension.class)
+//public final class ZookeeperSyncDataServiceTest {
+//
+//    private static final String MOCK_PLUGIN_PARENT_PATH = "/shenyu/plugin";
+//
+//    private static final String MOCK_PLUGIN_PATH = "/shenyu/plugin/divide";
+//
+//    private static final String MOCK_PLUGIN_NAME = "divide";
+//
+//    private static final String MOCK_SELECTOR_PARENT_PATH = "/shenyu/selector/divide";
+//
+//    private static final String MOCK_SELECTOR_PATH = "/shenyu/selector/divide/test";
+//
+//    private static final String MOCK_SELECTOR_NAME = "test";
+//
+//    private static final String MOCK_RULE_PARENT_PATH = "/shenyu/rule/divide";
+//
+//    private static final String MOCK_RULE_PATH = "/shenyu/rule/divide/test-test";
+//
+//    private static final String MOCK_RULE_NAME = "test-test";
+//
+//    private static final String MOCK_APP_AUTH_PARENT_PATH = "/shenyu/auth";
+//
+//    private static final String MOCK_APP_AUTH_PATH = "/shenyu/auth/test";
+//
+//    private static final String MOCK_APP_AUTH_KEY = "test";
+//
+//    private static final String MOCK_META_DATA_PARENT_PATH = "/shenyu/metaData";
+//
+//    private static final String MOCK_META_DATA_PATH = "/shenyu/metaData/test";
+//
+//    private static final String MOCK_META_DATA_ID = "test";
+//
+//    private ZkClient zkClient;
+//
+//    private ZookeeperSyncDataService syncDataService;
+//
+//    @BeforeEach
+//    public void setUp() {
+//        zkClient = mock(ZkClient.class);
+//        //mock plugin data & method
+//        PluginData pluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.FALSE).build();
+//        when(zkClient.exists(anyString())).thenReturn(Boolean.FALSE);
+//        when(zkClient.readData(MOCK_PLUGIN_PATH)).thenReturn(GsonUtils.getInstance().toJson(pluginData));
+//        when(zkClient.getChildren(MOCK_PLUGIN_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_PLUGIN_NAME));
+//        //mock selector data & method
+//        SelectorData selectorData = SelectorData.builder().name(MOCK_SELECTOR_NAME).enabled(Boolean.FALSE).build();
+//        when(zkClient.readData(MOCK_SELECTOR_PATH)).thenReturn(GsonUtils.getInstance().toJson(selectorData));
+//        when(zkClient.getChildren(MOCK_SELECTOR_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_SELECTOR_NAME));
+//        //mock rule data & method
+//        RuleData ruleData = RuleData.builder().name(MOCK_RULE_NAME).enabled(Boolean.FALSE).build();
+//        when(zkClient.readData(MOCK_RULE_PATH)).thenReturn(GsonUtils.getInstance().toJson(ruleData));
+//        when(zkClient.getChildren(MOCK_RULE_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_RULE_NAME));
+//        //mock auth data & method
+//        AppAuthData appAuthData = AppAuthData.builder().appKey(MOCK_APP_AUTH_KEY).enabled(Boolean.FALSE).build();
+//        when(zkClient.readData(MOCK_APP_AUTH_PATH)).thenReturn(GsonUtils.getInstance().toJson(appAuthData));
+//        when(zkClient.getChildren(MOCK_APP_AUTH_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_APP_AUTH_KEY));
+//        //mock meta data & method
+//        MetaData metaData = MetaData.builder().id(MOCK_META_DATA_ID).enabled(Boolean.FALSE).build();
+//        when(zkClient.readData(MOCK_META_DATA_PATH)).thenReturn(GsonUtils.getInstance().toJson(metaData));
+//        when(zkClient.getChildren(MOCK_META_DATA_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_META_DATA_ID));
+//    }
+//
+//    @Test
+//    public void testWatchPluginWhenInit() {
+//        final List<PluginData> subscribeList = new ArrayList<>(1);
+//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+//            @Override
+//            public void onSubscribe(final PluginData pluginData) {
+//                subscribeList.add(pluginData);
+//            }
+//        }, Collections.emptyList(), Collections.emptyList());
+//        assertThat(subscribeList.size(), is(1));
+//        assertThat(subscribeList.get(0).getName(), is("divide"));
+//    }
+//
+//    @Test
+//    public void testWatchPluginWhenDataChange() throws Exception {
+//        final PluginData changedPluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.TRUE).build();
+//        final List<PluginData> subscribeList = new ArrayList<>(2);
+//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+//            @Override
+//            public void onSubscribe(final PluginData pluginData) {
+//                subscribeList.add(pluginData);
+//            }
+//        }, Collections.emptyList(), Collections.emptyList());
+//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
+//        verify(zkClient).subscribeDataChanges(eq(MOCK_PLUGIN_PATH), captor.capture());
+//        captor.getValue().handleDataChange(MOCK_PLUGIN_PATH, GsonUtils.getInstance().toJson(changedPluginData));
+//        assertThat(subscribeList.size(), is(2));
+//        assertTrue(subscribeList.get(1).getEnabled());
+//    }
+//
+//    @Test
+//    public void testWatchPluginWhenDataDeleted() throws Exception {
+//        final List<PluginData> unSubscribeList = new ArrayList<>(1);
+//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+//            @Override
+//            public void unSubscribe(final PluginData pluginData) {
+//                unSubscribeList.add(pluginData);
+//            }
+//        }, Collections.emptyList(), Collections.emptyList());
+//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
+//        verify(zkClient).subscribeDataChanges(eq(MOCK_PLUGIN_PATH), captor.capture());
+//        captor.getValue().handleDataDeleted(MOCK_PLUGIN_PATH);
+//        assertThat(unSubscribeList.size(), is(1));
+//        assertThat(unSubscribeList.get(0).getName(), is("divide"));
+//    }
+//
+//    @Test
+//    public void testWatchSelectorWhenInit() {
+//        final List<SelectorData> subscribeList = new ArrayList<>(1);
+//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+//            @Override
+//            public void onSelectorSubscribe(final SelectorData selectorData) {
+//                subscribeList.add(selectorData);
+//            }
+//        }, Collections.emptyList(), Collections.emptyList());
+//        assertThat(subscribeList.size(), is(1));
+//        assertThat(subscribeList.get(0).getName(), is("test"));
+//    }
+//
+//    @Test
+//    public void testWatchSelectorWhenDataChange() throws Exception {
+//        final SelectorData changedSelectorData = SelectorData.builder().name(MOCK_SELECTOR_NAME).enabled(Boolean.TRUE).build();
+//        final List<SelectorData> subscribeList = new ArrayList<>(2);
+//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+//            @Override
+//            public void onSelectorSubscribe(final SelectorData selectorData) {
+//                subscribeList.add(selectorData);
+//            }
+//        }, Collections.emptyList(), Collections.emptyList());
+//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
+//        verify(zkClient).subscribeDataChanges(eq(MOCK_SELECTOR_PATH), captor.capture());
+//        captor.getValue().handleDataChange(MOCK_SELECTOR_PATH, GsonUtils.getInstance().toJson(changedSelectorData));
+//        assertThat(subscribeList.size(), is(2));
+//        assertTrue(subscribeList.get(1).getEnabled());
+//    }
+//
+//    @Test
+//    public void testWatchSelectorWhenDataDeleted() throws Exception {
+//        final List<SelectorData> unSubscribeList = new ArrayList<>(1);
+//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+//            @Override
+//            public void unSelectorSubscribe(final SelectorData selectorData) {
+//                unSubscribeList.add(selectorData);
+//            }
+//        }, Collections.emptyList(), Collections.emptyList());
+//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
+//        verify(zkClient).subscribeDataChanges(eq(MOCK_SELECTOR_PATH), captor.capture());
+//        captor.getValue().handleDataDeleted(MOCK_SELECTOR_PATH);
+//        assertThat(unSubscribeList.size(), is(1));
+//        assertThat(unSubscribeList.get(0).getId(), is("test"));
+//    }
+//
+//    @Test
+//    public void testWatchRuleWhenInit() {
+//        final List<RuleData> subscribeList = new ArrayList<>(1);
+//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+//            @Override
+//            public void onRuleSubscribe(final RuleData ruleData) {
+//                subscribeList.add(ruleData);
+//            }
+//        }, Collections.emptyList(), Collections.emptyList());
+//        assertThat(subscribeList.size(), is(1));
+//        assertThat(subscribeList.get(0).getName(), is(MOCK_RULE_NAME));
+//    }
+//
+//    @Test
+//    public void testWatchRuleWhenDataChange() throws Exception {
+//        final RuleData changedRuleData = RuleData.builder().name(MOCK_RULE_NAME).enabled(Boolean.TRUE).build();
+//        final List<RuleData> subscribeList = new ArrayList<>(2);
+//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+//            @Override
+//            public void onRuleSubscribe(final RuleData ruleData) {
+//                subscribeList.add(ruleData);
+//            }
+//        }, Collections.emptyList(), Collections.emptyList());
+//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
+//        verify(zkClient).subscribeDataChanges(eq(MOCK_RULE_PATH), captor.capture());
+//        captor.getValue().handleDataChange(MOCK_RULE_PATH, GsonUtils.getInstance().toJson(changedRuleData));
+//        assertThat(subscribeList.size(), is(2));
+//        assertTrue(subscribeList.get(1).getEnabled());
+//    }
+//
+//    @Test
+//    public void testWatchRuleWhenDataDeleted() throws Exception {
+//        final List<RuleData> unSubscribeList = new ArrayList<>(1);
+//        syncDataService = new ZookeeperSyncDataService(zkClient, new PluginDataSubscriber() {
+//            @Override
+//            public void unRuleSubscribe(final RuleData ruleData) {
+//                unSubscribeList.add(ruleData);
+//            }
+//        }, Collections.emptyList(), Collections.emptyList());
+//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
+//        verify(zkClient).subscribeDataChanges(eq(MOCK_RULE_PATH), captor.capture());
+//        captor.getValue().handleDataDeleted(MOCK_RULE_PATH);
+//        assertThat(unSubscribeList.size(), is(1));
+//        assertThat(unSubscribeList.get(0).getSelectorId() + DefaultPathConstants.SELECTOR_JOIN_RULE + unSubscribeList.get(0).getId(), is(MOCK_RULE_NAME));
+//    }
+//
+//    @Test
+//    public void testWatchAppAuthWhenInit() {
+//        final List<AppAuthData> subscribeList = new ArrayList<>(1);
+//        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
+//            @Override
+//            public void onSubscribe(final AppAuthData appAuthData) {
+//                subscribeList.add(appAuthData);
+//            }
+//
+//            @Override
+//            public void unSubscribe(final AppAuthData appAuthData) {
+//            }
+//        };
+//        syncDataService = new ZookeeperSyncDataService(zkClient,
+//                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
+//        assertThat(subscribeList.size(), is(1));
+//    }
+//
+//    @Test
+//    public void testWatchAppAuthWhenDataChange() throws Exception {
+//        final AppAuthData changedAppAuthData = AppAuthData.builder().appKey("test").enabled(Boolean.TRUE).build();
+//        final List<AppAuthData> subscribeList = new ArrayList<>(1);
+//        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
+//            @Override
+//            public void onSubscribe(final AppAuthData appAuthData) {
+//                subscribeList.add(appAuthData);
+//            }
+//
+//            @Override
+//            public void unSubscribe(final AppAuthData appAuthData) {
+//            }
+//        };
+//        syncDataService = new ZookeeperSyncDataService(zkClient,
+//                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
+//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
+//        verify(zkClient).subscribeDataChanges(eq(MOCK_APP_AUTH_PATH), captor.capture());
+//        captor.getValue().handleDataChange(MOCK_APP_AUTH_PATH, GsonUtils.getInstance().toJson(changedAppAuthData));
+//        assertThat(subscribeList.size(), is(2));
+//        assertTrue(subscribeList.get(1).getEnabled());
+//    }
+//
+//    @Test
+//    public void testWatchAppAuthWhenDataDeleted() throws Exception {
+//        final List<AppAuthData> unSubscribeList = new ArrayList<>(1);
+//        AuthDataSubscriber authDataSubscriber = new AuthDataSubscriber() {
+//            @Override
+//            public void onSubscribe(final AppAuthData appAuthData) {
+//            }
+//
+//            @Override
+//            public void unSubscribe(final AppAuthData appAuthData) {
+//                unSubscribeList.add(appAuthData);
+//            }
+//        };
+//        syncDataService = new ZookeeperSyncDataService(zkClient,
+//                null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
+//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
+//        verify(zkClient).subscribeDataChanges(eq(MOCK_APP_AUTH_PATH), captor.capture());
+//        captor.getValue().handleDataDeleted(MOCK_APP_AUTH_PATH);
+//        assertThat(unSubscribeList.size(), is(1));
+//        assertThat(unSubscribeList.get(0).getAppKey(), is(MOCK_APP_AUTH_KEY));
+//    }
+//
+//    @Test
+//    public void testWatchMetaDataWhenInit() {
+//        final List<MetaData> subscribeList = new ArrayList<>(1);
+//        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
+//            @Override
+//            public void onSubscribe(final MetaData metaData) {
+//                subscribeList.add(metaData);
+//            }
+//
+//            @Override
+//            public void unSubscribe(final MetaData metaData) {
+//            }
+//        };
+//        syncDataService = new ZookeeperSyncDataService(zkClient,
+//                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
+//        assertThat(subscribeList.size(), is(1));
+//    }
+//
+//    @Test
+//    public void testWatchMetaDataWhenDataChange() throws Exception {
+//        final MetaData changedMetaData = MetaData.builder().id(MOCK_META_DATA_ID).enabled(Boolean.TRUE).build();
+//        final List<MetaData> subscribeList = new ArrayList<>(2);
+//        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
+//            @Override
+//            public void onSubscribe(final MetaData metaData) {
+//                subscribeList.add(metaData);
+//            }
+//
+//            @Override
+//            public void unSubscribe(final MetaData metaData) {
+//            }
+//        };
+//        syncDataService = new ZookeeperSyncDataService(zkClient,
+//                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
+//        assertEquals(1, subscribeList.size());
+//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
+//        verify(zkClient).subscribeDataChanges(eq(MOCK_META_DATA_PATH), captor.capture());
+//        captor.getValue().handleDataChange(MOCK_META_DATA_PATH, GsonUtils.getInstance().toJson(changedMetaData));
+//        assertThat(subscribeList.size(), is(2));
+//        assertTrue(subscribeList.get(1).getEnabled());
+//    }
+//
+//    @Test
+//    public void testWatchMetaDataWhenDataDeleted() throws Exception {
+//        final List<MetaData> unSubscribeList = new ArrayList<>(1);
+//        MetaDataSubscriber metaDataSubscriber = new MetaDataSubscriber() {
+//            @Override
+//            public void onSubscribe(final MetaData metaData) {
+//            }
+//
+//            @Override
+//            public void unSubscribe(final MetaData metaData) {
+//                unSubscribeList.add(metaData);
+//            }
+//        };
+//        syncDataService = new ZookeeperSyncDataService(zkClient,
+//                null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
+//        ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
+//        verify(zkClient).subscribeDataChanges(eq(MOCK_META_DATA_PATH), captor.capture());
+//        captor.getValue().handleDataDeleted(MOCK_META_DATA_PATH);
+//        assertThat(unSubscribeList.size(), is(1));
+//        assertThat(unSubscribeList.get(0).getPath(), is(MOCK_META_DATA_ID));
+//    }
+//
+//    @AfterEach
+//    public void tearDown() {
+//        syncDataService.close();
+//    }
+//}


### PR DESCRIPTION
For #3362 , replace `zkclient` with `curator`, version 5.2.1. ~~To avoid huge PR, I plan to split with 2 PRs. For this one,~~ It mainly done following things.

- added new `zookeeperClient` class in each module and added UT.
- refactored `admin` register server class and added unit test.
- refactored `client` register client class and added UT.
- refactored `register-instance` class and added UT.
- refactored data-sync in admin and bootstrap module and added UT.
- update LICENSE file in `admin-dist` and `bootstrap-dist`.
- removed magic header when saving data in zookeeper server.

Now it works well for registration and data sync.

~~I'll implement the *data-sync* in `admin` and `bootstrap` in the next PR.~~

BTW, for some UT, I replace mocking `zkClient` with adding `TestingServer` provided by `curator-test`. It's better to help to verify the behaviors like operating with real zk server.

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
