### PR TITLE
[Task #3407] add the logic of annotation on the splicing class: gRPC

### DIFF
--- a/shenyu-client/shenyu-client-grpc/src/main/java/org/apache/shenyu/client/grpc/GrpcClientBeanPostProcessor.java
+++ b/shenyu-client/shenyu-client-grpc/src/main/java/org/apache/shenyu/client/grpc/GrpcClientBeanPostProcessor.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -125,9 +126,8 @@ public class GrpcClientBeanPostProcessor implements BeanPostProcessor {
             return;
         }
         ShenyuGrpcClient grpcClassAnnotation = AnnotationUtils.findAnnotation(clazz, ShenyuGrpcClient.class);
-        String basePath = Objects.nonNull(grpcClassAnnotation)
-                ? StringUtils.defaultIfBlank(grpcClassAnnotation.path(), "")
-                : "";
+        String basePath = Optional.ofNullable(grpcClassAnnotation)
+                .map(annotation -> StringUtils.defaultIfBlank(grpcClassAnnotation.path(), "")).orElse("");
         if (basePath.contains("*")) {
             Method[] methods = ReflectionUtils.getDeclaredMethods(clazz);
             for (Method method : methods) {

--- a/shenyu-examples/shenyu-examples-grpc/src/main/http/grpc-class-annotation-test-api.http
+++ b/shenyu-examples/shenyu-examples-grpc/src/main/http/grpc-class-annotation-test-api.http
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+### shengyu gateway proxy helloService#hello
+POST http://localhost:9195/grpc/helloService/hello
+Accept: application/json
+Content-Type: application/json
+
+{
+  "data":[
+    {
+      "data": "zhangSan"
+    }
+  ]
+}
+
+### shengyu gateway proxy helloService#helloEveryOne
+POST http://localhost:9195/grpc/helloService/helloEveryOne
+Accept: application/json
+Content-Type: application/json
+
+{
+  "data": [
+    {
+      "data": "zhangSan"
+    },
+    {
+      "data": "lisi"
+    }
+  ]
+}
+
+### shengyu gateway proxy eventService#sendEvent
+POST http://localhost:9195/grpc/eventService/sendEvent
+Accept: application/json
+Content-Type: application/json
+
+{
+  "data":[
+    {
+      "data": "startup"
+    }
+  ]
+}
+
+### shengyu gateway proxy eventService#sendEventStream
+POST http://localhost:9195/grpc/eventService/sendEventStream
+Accept: application/json
+Content-Type: application/json
+
+{
+  "data": [
+    {
+      "data": "startup"
+    },
+    {
+      "data": "pause"
+    }
+  ]
+}
+
+### shengyu gateway proxy clientStreamingFun
+POST http://localhost:9195/grpc/serverStreamingFun
+Accept: application/json
+Content-Type: application/json
+
+{
+  "data": [
+    {
+      "message": "hello grpc"
+    },
+    {
+      "message": "hello grpc"
+    }
+  ]
+}

--- a/shenyu-examples/shenyu-examples-grpc/src/main/http/grpc-class-annotation-test-api.http
+++ b/shenyu-examples/shenyu-examples-grpc/src/main/http/grpc-class-annotation-test-api.http
@@ -74,18 +74,3 @@ Content-Type: application/json
   ]
 }
 
-### shengyu gateway proxy clientStreamingFun
-POST http://localhost:9195/grpc/serverStreamingFun
-Accept: application/json
-Content-Type: application/json
-
-{
-  "data": [
-    {
-      "message": "hello grpc"
-    },
-    {
-      "message": "hello grpc"
-    }
-  ]
-}

--- a/shenyu-examples/shenyu-examples-grpc/src/main/java/org/apache/shenyu/examples/grpc/demo/EventServiceImpl.java
+++ b/shenyu-examples/shenyu-examples-grpc/src/main/java/org/apache/shenyu/examples/grpc/demo/EventServiceImpl.java
@@ -1,0 +1,50 @@
+package org.apache.shenyu.examples.grpc.demo;
+
+
+import event.EventRequest;
+import event.EventResponse;
+import event.EventServiceGrpc;
+import io.grpc.stub.StreamObserver;
+import org.apache.shenyu.client.grpc.common.annotation.ShenyuGrpcClient;
+import org.springframework.stereotype.Service;
+
+@ShenyuGrpcClient(path = "/eventService", desc = "event")
+@Service
+public class EventServiceImpl extends EventServiceGrpc.EventServiceImplBase {
+
+    @ShenyuGrpcClient(path = "/sendEvent", desc = "sendEvent")
+    @Override
+    public void sendEvent(EventRequest request, StreamObserver<EventResponse> responseObserver) {
+        EventResponse response = EventResponse.newBuilder().setData("received event:" + request.getData()).build();
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @ShenyuGrpcClient(path = "/sendEventStream", desc = "sendEventStream")
+    @Override
+    public StreamObserver<EventRequest> sendEventStream(StreamObserver<EventResponse> responseObserver) {
+        return new StreamObserver<EventRequest>() {
+            @Override
+            public void onNext(EventRequest request) {
+                EventResponse responseData = EventResponse.newBuilder()
+                        .setData("received event:" + request.getData())
+                        .build();
+                responseObserver.onNext(responseData);
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                t.printStackTrace();
+            }
+
+            @Override
+            public void onCompleted() {
+                EventResponse responseData = EventResponse.newBuilder()
+                        .setData("event onCompleted")
+                        .build();
+                responseObserver.onNext(responseData);
+                responseObserver.onCompleted();
+            }
+        };
+    }
+}

--- a/shenyu-examples/shenyu-examples-grpc/src/main/java/org/apache/shenyu/examples/grpc/demo/EventServiceImpl.java
+++ b/shenyu-examples/shenyu-examples-grpc/src/main/java/org/apache/shenyu/examples/grpc/demo/EventServiceImpl.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shenyu.examples.grpc.demo;
 
 

--- a/shenyu-examples/shenyu-examples-grpc/src/main/java/org/apache/shenyu/examples/grpc/demo/HelloServiceImpl.java
+++ b/shenyu-examples/shenyu-examples-grpc/src/main/java/org/apache/shenyu/examples/grpc/demo/HelloServiceImpl.java
@@ -1,4 +1,20 @@
 package org.apache.shenyu.examples.grpc.demo;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import hello.HelloRequest;
 import hello.HelloResponse;

--- a/shenyu-examples/shenyu-examples-grpc/src/main/java/org/apache/shenyu/examples/grpc/demo/HelloServiceImpl.java
+++ b/shenyu-examples/shenyu-examples-grpc/src/main/java/org/apache/shenyu/examples/grpc/demo/HelloServiceImpl.java
@@ -1,0 +1,48 @@
+package org.apache.shenyu.examples.grpc.demo;
+
+import hello.HelloRequest;
+import hello.HelloResponse;
+import hello.HelloServiceGrpc;
+import io.grpc.stub.StreamObserver;
+import org.apache.shenyu.client.grpc.common.annotation.ShenyuGrpcClient;
+import org.springframework.stereotype.Service;
+
+
+@ShenyuGrpcClient(path = "/helloService/**", desc = "hello")
+@Service
+public class HelloServiceImpl extends HelloServiceGrpc.HelloServiceImplBase {
+
+    @Override
+    public void hello(HelloRequest request, StreamObserver<HelloResponse> responseObserver) {
+        HelloResponse response = HelloResponse.newBuilder().setData("hello: " + request.getData()).build();
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public StreamObserver<HelloRequest> helloEveryOne(StreamObserver<HelloResponse> responseObserver) {
+        return new StreamObserver<HelloRequest>() {
+            @Override
+            public void onNext(HelloRequest request) {
+                HelloResponse responseData = HelloResponse.newBuilder()
+                        .setData("hello: " + request.getData())
+                        .build();
+                responseObserver.onNext(responseData);
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                t.printStackTrace();
+            }
+
+            @Override
+            public void onCompleted() {
+                HelloResponse responseData = HelloResponse.newBuilder()
+                        .setData("hello onCompleted")
+                        .build();
+                responseObserver.onNext(responseData);
+                responseObserver.onCompleted();
+            }
+        };
+    }
+}

--- a/shenyu-examples/shenyu-examples-grpc/src/main/resources/proto/event.proto
+++ b/shenyu-examples/shenyu-examples-grpc/src/main/resources/proto/event.proto
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+syntax = "proto3";
+
+package event;
+
+option java_multiple_files = true;
+
+
+service EventService {
+  rpc sendEvent (EventRequest) returns (EventResponse) {}
+
+  rpc sendEventStream(stream EventRequest) returns (stream EventResponse) {}
+}
+
+message EventRequest {
+  string data = 1;
+}
+
+message EventResponse {
+  string data = 1;
+}
+

--- a/shenyu-examples/shenyu-examples-grpc/src/main/resources/proto/hello.proto
+++ b/shenyu-examples/shenyu-examples-grpc/src/main/resources/proto/hello.proto
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+syntax = "proto3";
+
+package hello;
+
+option java_multiple_files = true;
+
+
+service HelloService {
+  rpc hello (HelloRequest) returns (HelloResponse) {}
+
+  rpc helloEveryOne(stream HelloRequest) returns (stream HelloResponse) {}
+}
+
+message HelloRequest {
+  string data = 1;
+}
+
+message HelloResponse {
+  string data = 1;
+}
+


### PR DESCRIPTION
Task #3407
add the logic of annotation on the splicing class for all rpc shenyu client: subtask-grpc

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.

---
test:

## startup 
1.startup admin,startup gateway, startup example grpc

## register
![image](https://user-images.githubusercontent.com/12478263/170852512-12f987ad-0110-4715-878c-85d6851386ad.png)


## test case 

case in file: `shenyu-examples/shenyu-examples-grpc/src/main/http/grpc-class-annotation-test-api.http`

### 1. test class annotation:


`
curl --location --request POST 'http://localhost:9195/grpc/helloService/hello' \
--header 'Content-Type: application/json' \
--data-raw '{
    "data":[
        {
            "data": "zhangsan"
        }
    ]
}'
`

---

`curl --location --request POST 'http://localhost:9195/grpc/helloService/helloEveryOne' \
--header 'Content-Type: application/json' \
--data-raw '{
    "data": [
        {
            "data": "zhangsan"
        },
        {
            "data": "lisi"
        }
    ]
}'`

### 2. test old service

`
curl --location --request POST 'http://localhost:9195/grpc/unaryFun' \
--header 'Content-Type: application/json' \
--data-raw '{
    "data":[
        {
            "text":"hello unaryFun"
        }
    ]
}'
`

---

`
curl --location --request POST 'http://localhost:9195/grpc/bidiStreamingFun' \
--header 'Content-Type: application/json' \
--data-raw '{
    "data": [
        {
            "text": "hello bidiStreamingFun"
        },
        {
            "text": "hello bidiStreamingFun"
        }
    ]
}'
`

## test result
Test case meets expectations






