### PR TITLE
[ISSUE #3461] fix issue that can't run sofa application using zk registration

### DIFF
--- a/shenyu-bootstrap/pom.xml
+++ b/shenyu-bootstrap/pom.xml
@@ -28,6 +28,7 @@
     <properties>
         <nacos-discovery.version>2021.0.1.0</nacos-discovery.version>
         <eureka-client.version>3.1.2</eureka-client.version>
+        <bootstrap-curator.version>4.0.1</bootstrap-curator.version>
     </properties>
 
     <dependencies>
@@ -454,7 +455,24 @@
             <version>${project.version}</version>
         </dependency>
         <!--shenyu logging-rocketmq plugin end-->
-        
+
+        <!-- curator start -->
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+            <version>${bootstrap-curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>${bootstrap-curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${bootstrap-curator.version}</version>
+        </dependency>
+        <!-- curator end -->
     </dependencies>
     <profiles>
         <profile>

--- a/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml
+++ b/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml
@@ -28,14 +28,44 @@
     <artifactId>shenyu-examples-sofa-service</artifactId>
 
     <properties>
-        <rpc-sofa-boot-starter.version>6.0.4</rpc-sofa-boot-starter.version>
+        <rpc-sofa-boot-starter.version>3.12.1</rpc-sofa-boot-starter.version>
+        <curator.version>4.0.1</curator.version>
+        <micrometer.version>1.8.6</micrometer.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.alipay.sofa</groupId>
+                <artifactId>sofaboot-dependencies</artifactId>
+                <version>${rpc-sofa-boot-starter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>rpc-sofa-boot-starter</artifactId>
             <version>${rpc-sofa-boot-starter.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
         </dependency>
 
         <!--shenyu consul register center -->
@@ -71,6 +101,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${micrometer.version}</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo

For #3461 , the root cause is because the curator version used in sofa (ver 4.0.1) is not compatible with 5.2.1. There're several options,
1. Downgrade curator version in `bootstrap`. It will succeed to run sofa applications, but will failed to sync data based on `zookeeper` for `bootstrap`. I can create another PR to find any walk around to fix it in `bootstrap`.
2. The other option is tell customers in official documents about this, and let them add ver 4.0.1 curator dependencies by themselves. And let them know the pros and cons.

This PR is follow option 1, it added curator ver 4.0.1 into `bootstrap` pom file, and I'll create another PR to fix the data sync issue in `bootstrap` when using 4.0.1.

There're also some other changes, since the `sofa-example` are out-of-date and are using curator 2.9.1, which even can't not start up. So I upgraded to sofa version 3.12.1, which is released by Apr. 2022.

Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
