### PR TITLE
[ISSUE #3475] Fix sofa, motan and dubbo don't work issue caused by Curator version incompatible in bootstrap

### DIFF
--- a/shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE
+++ b/shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE
@@ -236,9 +236,9 @@ The text of each license is the standard Apache 2.0 license.
     commons-jxpath 1.3: http://commons.apache.org/jxpath/, Apache 2.0
     commons-math 2.2: https://github.com/apache/commons-math, Apache 2.0
     conscrypt-openjdk-uber 2.5.1: https://conscrypt.org, Apache 2.0
-    curator-client 5.2.1:  https://github.com/apache/curator, Apache 2.0
-    curator-framework 5.2.1:  https://github.com/apache/curator, Apache 2.0
-    curator-recipes 5.2.1:  https://github.com/apache/curator, Apache 2.0
+    curator-client 4.0.1:  https://github.com/apache/curator, Apache 2.0
+    curator-framework 4.0.1:  https://github.com/apache/curator, Apache 2.0
+    curator-recipes 4.0.1:  https://github.com/apache/curator, Apache 2.0
     dubbo 2.6.5: https://github.com/apache/dubbo, Apache 2.0
     error_prone_annotations 2.5.1: https://github.com/google/error-prone, Apache 2.0
     failsafe 2.3.3: https://github.com/jhalterman/failsafe, Apache 2.0

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataService.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataService.java
@@ -18,9 +18,12 @@
 package org.apache.shenyu.sync.data.zookeeper;
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.curator.framework.recipes.cache.TreeCacheEvent;
+import org.apache.curator.framework.recipes.cache.TreeCacheListener;
 import org.apache.shenyu.common.constant.DefaultPathConstants;
 import org.apache.shenyu.common.dto.AppAuthData;
 import org.apache.shenyu.common.dto.MetaData;
@@ -168,14 +171,36 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         }
     }
 
-    class PluginCacheListener implements CuratorCacheListener {
+    abstract class AbstractDataSyncListener implements TreeCacheListener {
+        @Override
+        public final void childEvent(final CuratorFramework client, final TreeCacheEvent event) {
+            ChildData childData = event.getData();
+            if (null == childData) {
+                return;
+            }
+            String path = childData.getPath();
+            if (Strings.isNullOrEmpty(path)) {
+                return;
+            }
+            event(event.getType(), path, childData);
+        }
+
+        /**
+         * data sync event.
+         *
+         * @param type tree cache event type.
+         * @param path tree cache event path.
+         * @param data tree cache event data.
+         */
+        protected abstract void event(TreeCacheEvent.Type type, String path, ChildData data);
+    }
+
+    class PluginCacheListener extends AbstractDataSyncListener {
 
         private static final String PLUGIN_PATH = DefaultPathConstants.PLUGIN_PARENT + "/*";
 
         @Override
-        public void event(final Type type, final ChildData oldData, final ChildData data) {
-            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
-
+        public void event(final TreeCacheEvent.Type type, final String path, final ChildData data) {
             // if not uri register path, return.
             if (!PathMatchUtils.match(PLUGIN_PATH, path)) {
                 return;
@@ -184,7 +209,7 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
             String pluginName = path.substring(path.lastIndexOf("/") + 1);
 
             // delete a plugin
-            if (type.equals(Type.NODE_DELETED)) {
+            if (type.equals(TreeCacheEvent.Type.NODE_REMOVED)) {
                 final PluginData pluginData = new PluginData();
                 pluginData.setName(pluginName);
                 Optional.ofNullable(pluginDataSubscriber).ifPresent(e -> e.unSubscribe(pluginData));
@@ -196,21 +221,20 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         }
     }
 
-    class SelectorCacheListener implements CuratorCacheListener {
+    class SelectorCacheListener extends AbstractDataSyncListener {
 
         // /shenyu/selector/{plugin}/{selector}
         private static final String SELECTOR_PATH = DefaultPathConstants.SELECTOR_PARENT + "/*/*";
 
         @Override
-        public void event(final Type type, final ChildData oldData, final ChildData data) {
-            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
+        public void event(final TreeCacheEvent.Type type, final String path, final ChildData data) {
 
             // if not uri register path, return.
             if (!PathMatchUtils.match(SELECTOR_PATH, path)) {
                 return;
             }
 
-            if (type.equals(Type.NODE_DELETED)) {
+            if (type.equals(TreeCacheEvent.Type.NODE_REMOVED)) {
                 unCacheSelectorData(path);
             }
 
@@ -220,20 +244,18 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         }
     }
 
-    class MetadataCacheListener implements CuratorCacheListener {
+    class MetadataCacheListener extends AbstractDataSyncListener {
 
         private static final String META_DATA_PATH = DefaultPathConstants.META_DATA + "/*";
 
         @Override
-        public void event(final Type type, final ChildData oldData, final ChildData data) {
-            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
-
+        public void event(final TreeCacheEvent.Type type, final String path, final ChildData data) {
             // if not uri register path, return.
             if (!PathMatchUtils.match(META_DATA_PATH, path)) {
                 return;
             }
 
-            if (type.equals(Type.NODE_DELETED)) {
+            if (type.equals(TreeCacheEvent.Type.NODE_REMOVED)) {
                 final String realPath = path.substring(DefaultPathConstants.META_DATA.length() + 1);
                 MetaData metaData = new MetaData();
                 try {
@@ -250,20 +272,18 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         }
     }
 
-    class AuthCacheListener implements CuratorCacheListener {
+    class AuthCacheListener extends AbstractDataSyncListener {
 
         private static final String APP_AUTH_PATH = DefaultPathConstants.APP_AUTH_PARENT + "/*";
 
         @Override
-        public void event(final Type type, final ChildData oldData, final ChildData data) {
-            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
-
+        public void event(final TreeCacheEvent.Type type, final String path, final ChildData data) {
             // if not uri register path, return.
             if (!PathMatchUtils.match(APP_AUTH_PATH, path)) {
                 return;
             }
 
-            if (type.equals(Type.NODE_DELETED)) {
+            if (type.equals(TreeCacheEvent.Type.NODE_REMOVED)) {
                 unCacheAuthData(path);
             }
 
@@ -273,21 +293,19 @@ public class ZookeeperSyncDataService implements SyncDataService, AutoCloseable 
         }
     }
 
-    class RuleCacheListener implements CuratorCacheListener {
+    class RuleCacheListener extends AbstractDataSyncListener {
 
         // /shenyu/rule/{plugin}/{rule}
         private static final String RULE_PATH = DefaultPathConstants.RULE_PARENT + "/*/*";
 
         @Override
-        public void event(final Type type, final ChildData oldData, final ChildData data) {
-            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
-
+        public void event(final TreeCacheEvent.Type type, final String path, final ChildData data) {
             // if not uri register path, return.
             if (!PathMatchUtils.match(RULE_PATH, path)) {
                 return;
             }
 
-            if (type.equals(Type.NODE_DELETED)) {
+            if (type.equals(TreeCacheEvent.Type.NODE_REMOVED)) {
                 unCacheRuleData(path);
             }
 


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo

For #3475 , related issue and PR links: #3461  #3470.

This PR has done following things,
- replace `CuratorCache` with `TreeCache`, which class is both exists in ver 4.0.1 and 5.2.1.
- test and make sure all works well for bootstrap zk data sync in my local machine.

Welcome to test and let me know if any comment. Thank you!

Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
