### PR TITLE
[type:feature] add github flow to publish docker image to ghcr.io

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: docker-publish
+
+on:
+  push:
+    branches: [ "master" ]
+    tags: [ 'v*.*.*' ]
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+  TAG: ${{ github.sha }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      - name: Build and push(admin)
+        uses: docker/build-push-action@v3
+        with:
+          context: ./shenyu-dist/shenyu-admin-dist
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/admin:${{ env.TAG }}
+
+      - name: Build and push(bootstrap)
+        uses: docker/build-push-action@v3
+        with:
+          context: ./shenyu-dist/shenyu-bootstrap-dist
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/bootstrap:${{ env.TAG }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,8 +38,12 @@ jobs:
         with:
           submodules: true
 
+      - name: Set Skip Env Var
+        uses: ./.github/actions/skip-ci
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
+        if: env.SKIP_CI != 'true'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -47,15 +51,36 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+        if: env.SKIP_CI != 'true'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        if: env.SKIP_CI != 'true'
 
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
+        if: env.SKIP_CI != 'true'
+
+      - name: Cache Maven Repos
+        if: env.SKIP_CI != 'true'
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - uses: actions/setup-java@v1
+        if: env.SKIP_CI != 'true'
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build with Maven
+        if: env.SKIP_CI != 'true'
+        run: ./mvnw -B clean package -Prelease
 
       - name: Build and push(admin)
         uses: docker/build-push-action@v3
+        if: env.SKIP_CI != 'true'
         with:
           context: ./shenyu-dist/shenyu-admin-dist
           platforms: linux/amd64,linux/arm64
@@ -64,6 +89,7 @@ jobs:
 
       - name: Build and push(bootstrap)
         uses: docker/build-push-action@v3
+        if: env.SKIP_CI != 'true'
         with:
           context: ./shenyu-dist/shenyu-bootstrap-dist
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This PR is intended to build docker image for every PR and publish it to `ghrc.io`.
it is helpful for building CI in sub-repos, like shenyu-nginx.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
