### PR TITLE
[ISSUE #3556] downgrade curator version to 4.3.0 to compatible with some plugin like sofa

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,9 @@
         <tars.version>1.7.2</tars.version>
         <skipTests>false</skipTests>
         <undertow.version>2.2.2.Final</undertow.version>
-        <curator.version>5.2.1</curator.version>
+        <curator.version>4.3.0</curator.version>
         <wiremock.version>2.18.0</wiremock.version>
-        <zookeeper.version>3.6.3</zookeeper.version>
+        <zookeeper.version>3.5.7</zookeeper.version>
         <zkclient.version>0.10</zkclient.version>
         <shiro.version>1.8.0</shiro.version>
         <jwt.version>3.12.0</jwt.version>
@@ -430,11 +430,6 @@
             <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
-                <version>${curator.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.curator</groupId>
-                <artifactId>curator-x-async</artifactId>
                 <version>${curator.version}</version>
             </dependency>
             <dependency>

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/zookeeper/HttpServiceDiscovery.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/zookeeper/HttpServiceDiscovery.java
@@ -19,8 +19,9 @@ package org.apache.shenyu.admin.listener.zookeeper;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.TreeCacheEvent;
+import org.apache.curator.framework.recipes.cache.TreeCacheListener;
 import org.apache.shenyu.admin.listener.DataChangedEvent;
 import org.apache.shenyu.admin.mapper.SelectorMapper;
 import org.apache.shenyu.admin.model.entity.SelectorDO;
@@ -162,11 +163,10 @@ public class HttpServiceDiscovery implements InitializingBean {
         }).collect(Collectors.toList());
     }
 
-    class HttpServiceListener implements CuratorCacheListener {
+    class HttpServiceListener implements TreeCacheListener {
         @Override
-        public void event(final Type type, final ChildData oldData, final ChildData data) {
-            String path = Objects.isNull(data) ? oldData.getPath() : data.getPath();
-
+        public void childEvent(final CuratorFramework client, final TreeCacheEvent event) throws Exception {
+            String path = event.getData().getPath();
             // if not uri register path, return.
             if (!PathMatchUtils.match(URI_PATH, path)) {
                 return;

--- a/shenyu-bootstrap/pom.xml
+++ b/shenyu-bootstrap/pom.xml
@@ -28,7 +28,6 @@
     <properties>
         <nacos-discovery.version>2021.0.1.0</nacos-discovery.version>
         <eureka-client.version>3.1.2</eureka-client.version>
-        <curator.version>4.0.1</curator.version>
     </properties>
 
     <dependencies>
@@ -461,25 +460,6 @@
             <version>${project.version}</version>
         </dependency>
         <!--shenyu logging-rocketmq plugin end-->
-
-        <!-- curator start -->
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-client</artifactId>
-            <version>${curator.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-framework</artifactId>
-            <version>${curator.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-recipes</artifactId>
-            <version>${curator.version}</version>
-        </dependency>
-        <!-- curator end -->
-
     </dependencies>
     <profiles>
         <profile>

--- a/shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE
+++ b/shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE
@@ -318,11 +318,11 @@ The text of each license is the standard Apache 2.0 license.
     tomcat-embed-el 9.0.29: https://tomcat.apache.org, Apache 2.0
     tomcat-embed-websocket 9.0.29: https://tomcat.apache.org, Apache 2.0
     unbescape 1.1.6.RELEASE: http://www.unbescape.org, Apache 2.0
-    zookeeper 3.6.3: https://github.com/apache/zookeeper, Apache 2.0
-    zookeeper-jute 3.6.3: https://github.com/apache/zookeeper, Apache 2.0
-    curator-client 5.2.1: https://github.com/apache/curator, Apache 2.0
-    curator-framework 5.2.1: https://github.com/apache/curator, Apache 2.0
-    curator-recipes 5.2.1: https://github.com/apache/curator, Apache 2.0
+    zookeeper 3.5.7: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper-jute 3.5.7: https://github.com/apache/zookeeper, Apache 2.0
+    curator-client 4.3.0: https://github.com/apache/curator, Apache 2.0
+    curator-framework 4.3.0: https://github.com/apache/curator, Apache 2.0
+    curator-recipes 4.3.0: https://github.com/apache/curator, Apache 2.0
 
 ========================================================================
 BSD licenses

--- a/shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE
+++ b/shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE
@@ -236,9 +236,9 @@ The text of each license is the standard Apache 2.0 license.
     commons-jxpath 1.3: http://commons.apache.org/jxpath/, Apache 2.0
     commons-math 2.2: https://github.com/apache/commons-math, Apache 2.0
     conscrypt-openjdk-uber 2.5.1: https://conscrypt.org, Apache 2.0
-    curator-client 4.0.1:  https://github.com/apache/curator, Apache 2.0
-    curator-framework 4.0.1:  https://github.com/apache/curator, Apache 2.0
-    curator-recipes 4.0.1:  https://github.com/apache/curator, Apache 2.0
+    curator-client 4.3.0:  https://github.com/apache/curator, Apache 2.0
+    curator-framework 4.3.0:  https://github.com/apache/curator, Apache 2.0
+    curator-recipes 4.3.0:  https://github.com/apache/curator, Apache 2.0
     dubbo 2.6.5: https://github.com/apache/dubbo, Apache 2.0
     error_prone_annotations 2.5.1: https://github.com/google/error-prone, Apache 2.0
     failsafe 2.3.3: https://github.com/jhalterman/failsafe, Apache 2.0
@@ -353,8 +353,8 @@ The text of each license is the standard Apache 2.0 license.
     vavr 0.10.2: http://vavr.io, Apache 2.0
     vavr-match 0.10.2: http://vavr.io, Apache 2.0
     zkclient 0.10: https://github.com/sgroschupf/zkclient, Apache 2.0
-    zookeeper 3.6.3: https://github.com/apache/zookeeper, Apache 2.0
-    zookeeper-jute 3.6.3: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper 3.5.7: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper-jute 3.5.7: https://github.com/apache/zookeeper, Apache 2.0
     byte-buddy 1.12.6: https://github.com/raphw/byte-buddy, Apache 2.0
     byte-buddy-agent 1.12.6: https://github.com/raphw/byte-buddy, Apache 2.0
     disruptor 3.4.0 https://github.com/LMAX-Exchange/disruptor, Apache 2.0

--- a/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml
+++ b/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <rpc-sofa-boot-starter.version>3.12.1</rpc-sofa-boot-starter.version>
-        <curator.version>4.0.1</curator.version>
+<!--        <curator.version>4.3.0</curator.version>-->
         <micrometer.version>1.8.6</micrometer.version>
     </properties>
 
@@ -52,21 +52,21 @@
             <version>${rpc-sofa-boot-starter.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-client</artifactId>
-            <version>${curator.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-framework</artifactId>
-            <version>${curator.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-recipes</artifactId>
-            <version>${curator.version}</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.apache.curator</groupId>-->
+<!--            <artifactId>curator-client</artifactId>-->
+<!--            <version>${curator.version}</version>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.apache.curator</groupId>-->
+<!--            <artifactId>curator-framework</artifactId>-->
+<!--            <version>${curator.version}</version>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.apache.curator</groupId>-->
+<!--            <artifactId>curator-recipes</artifactId>-->
+<!--            <version>${curator.version}</version>-->
+<!--        </dependency>-->
 
         <!--shenyu consul register center -->
         <!--<dependency>

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
@@ -16,7 +16,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client</artifactId>

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientTest.java
@@ -18,7 +18,7 @@
 package org.apache.shenyu.register.client.zookeeper;
 
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.curator.test.TestingServer;
 import org.apache.shenyu.common.dto.MetaData;
 import org.apache.shenyu.common.utils.GsonUtils;
@@ -126,7 +126,7 @@ class ZookeeperClientTest {
 
     @Test
     void getCache() {
-        CuratorCache cache = client.getCache("/test");
+        TreeCache cache = client.getCache("/test");
         assertNull(cache);
 
         client.addCache("/test");
@@ -137,7 +137,7 @@ class ZookeeperClientTest {
     @Test
     void addCache() {
         client.addCache("/test");
-        CuratorCache cache = client.getCache("/test");
+        TreeCache cache = client.getCache("/test");
         assertNotNull(cache);
     }
 }

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperClientTest.java
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/src/test/java/org/apache/shenyu/register/instance/zookeeper/ZookeeperClientTest.java
@@ -18,7 +18,7 @@
 package org.apache.shenyu.register.instance.zookeeper;
 
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.curator.test.TestingServer;
 import org.apache.shenyu.common.dto.MetaData;
 import org.apache.shenyu.common.utils.GsonUtils;
@@ -126,7 +126,7 @@ class ZookeeperClientTest {
 
     @Test
     void getCache() {
-        CuratorCache cache = client.getCache("/test");
+        TreeCache cache = client.getCache("/test");
         assertNull(cache);
 
         client.addCache("/test");
@@ -137,7 +137,7 @@ class ZookeeperClientTest {
     @Test
     void addCache() {
         client.addCache("/test");
-        CuratorCache cache = client.getCache("/test");
+        TreeCache cache = client.getCache("/test");
         assertNotNull(cache);
     }
 }

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml
@@ -25,11 +25,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sync-data-zookeeper</artifactId>
 
-    <properties>
-        <curator.version>4.0.1</curator.version>
-        <zookeeper.version>3.5.5</zookeeper.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.shenyu</groupId>
@@ -40,29 +35,15 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
-            <version>${curator.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
-            <version>${curator.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>${curator.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>${zookeeper.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>log4j</artifactId>
-                    <groupId>log4j</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

For #3556 , all tasks should be finished and the pom should be cleaned. I also changed `zookeeper` dep to `3.5.7` because the curator ver `4.3.0` depends on it. I've tested below functions and they're works well. Welcome to help to test these or others test cases!

- [x] data sync between admin and bootstrap
- [x] register between admin and sofa client
- [x] bootstrap instance
- [x] sofa example works well

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
