### PR TITLE
[type:Integration Test] add integrated-test of logging-rocketmq-plugin

### DIFF
--- a/.github/workflows/integrated-test.yml
+++ b/.github/workflows/integrated-test.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - master
+      - addRocketMqTest
 
 jobs:
   build:

--- a/.github/workflows/integrated-test.yml
+++ b/.github/workflows/integrated-test.yml
@@ -20,8 +20,6 @@ on:
   push:
     branches:
       - master
-      - addRocketMqTest
-
 jobs:
   build:
     strategy:

--- a/.github/workflows/integrated-test.yml
+++ b/.github/workflows/integrated-test.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - master
+
 jobs:
   build:
     strategy:

--- a/shenyu-integrated-test/shenyu-integrated-test-http/config/broker.conf
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/config/broker.conf
@@ -1,0 +1,7 @@
+brokerName = shenyu-broker
+brokerId = 0
+deleteWhen = 04
+fileReservedTime = 48
+brokerRole = ASYNC_MASTER 
+flushDiskType = ASYNC_FLUSH
+autoCreateTopicEnable=true

--- a/shenyu-integrated-test/shenyu-integrated-test-http/config/broker.conf
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/config/broker.conf
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 brokerName = shenyu-broker
 brokerId = 0
 deleteWhen = 04

--- a/shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml
@@ -81,7 +81,7 @@ services:
         limits:
           memory: 2048M
     environment:
-      - shenyu.sync.websocket.urls=ws://shenyu-admin:9095/websocket          
+      - shenyu.sync.websocket.urls=ws://shenyu-admin:9095/websocket
     depends_on:
       shenyu-admin:
         condition: service_healthy
@@ -127,6 +127,47 @@ services:
       test: [ "CMD", "wget", "http://localhost:9200/_cat/health?v" ]
       timeout: 2s
       retries: 30
+
+  shenyu-rocketmq:
+    image: rocketmqinc/rocketmq:4.3.2
+    container_name: shenyu-rocketmq
+    restart: always
+    depends_on:
+      shenyu-integrated-test-http:
+        condition: service_healthy
+    ports:
+      - "9876:9876"
+    environment:
+      JAVA_OPT_EXT: "-server -Xms1g -Xmx1g"
+    volumes:
+      - ./logs:/root/logs
+    command: sh mqnamesrv
+    networks:
+      shenyu:
+        aliases:
+          -  shenyu-rocketmq
+
+  shenyu-rmqbroker:
+    image: rocketmqinc/rocketmq:4.3.2
+    container_name: shenyu-rmqbroker
+    restart: always
+    depends_on:
+      - shenyu-rocketmq
+    ports:
+      - 10909:10909
+      - 10911:10911
+    volumes:
+      - ./logs:/root/logs
+      - ./store:/root/store
+      - ./config/broker.conf:/opt/rocketmq-4.4.0/conf/broker.conf
+    command: sh mqbroker  -c /opt/rocketmq-4.4.0/conf/broker.conf
+    environment:
+      NAMESRV_ADDR: "shenyu-rocketmq:9876"
+      JAVA_OPT_EXT: "-server -Xms1g -Xmx1g -Xmn1g"
+    networks:
+      shenyu:
+        aliases:
+          - shenyu-rmqbroker
 
 networks:
   shenyu:

--- a/shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       retries: 30
 
   shenyu-rocketmq:
-    image: rocketmqinc/rocketmq:4.3.2
+    image: apache/rocketmq:4.9.3
     container_name: shenyu-rocketmq
     restart: always
     depends_on:
@@ -148,7 +148,7 @@ services:
           -  shenyu-rocketmq
 
   shenyu-rmqbroker:
-    image: rocketmqinc/rocketmq:4.3.2
+    image: apache/rocketmq:4.9.3
     container_name: shenyu-rmqbroker
     restart: always
     depends_on:

--- a/shenyu-integrated-test/shenyu-integrated-test-http/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/pom.xml
@@ -178,6 +178,14 @@
         </dependency>
         <!--shenyu logging-elasticsearch plugin end-->
 
+        <!--shenyu logging-rocketmq plugin start-->
+        <dependency>
+            <groupId>org.apache.shenyu</groupId>
+            <artifactId>shenyu-spring-boot-starter-plugin-logging-rocketmq</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!--shenyu logging-rocketmq plugin end-->
+
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-integrated-test-common</artifactId>

--- a/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/RocketMqPluginTest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/RocketMqPluginTest.java
@@ -26,7 +26,6 @@ import org.apache.shenyu.plugin.logging.rocketmq.config.LogCollectConfig;
 import org.apache.shenyu.plugin.logging.rocketmq.client.RocketMQLogCollectClient;
 import org.apache.shenyu.plugin.logging.rocketmq.constant.LoggingConstant;
 import org.apache.shenyu.plugin.logging.rocketmq.utils.RocketLogCollectConfigUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,7 +34,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -61,7 +59,7 @@ public final class RocketMqPluginTest extends AbstractPluginDataInit {
 
     @Test
     public void testPass() {
-        LogCollectConfig.GlobalLogConfig globalLogConfig = GsonUtils.getInstance().fromJson(pluginData.getConfig(), LogCollectConfig.GlobalLogConfig.class);
+        final LogCollectConfig.GlobalLogConfig globalLogConfig = GsonUtils.getInstance().fromJson(pluginData.getConfig(), LogCollectConfig.GlobalLogConfig.class);
         properties.setProperty(LoggingConstant.TOPIC, "shenyu-access-logging");
         properties.setProperty(LoggingConstant.NAMESERVER_ADDRESS, "shenyu-rocketmq:9876");
         properties.setProperty(LoggingConstant.PRODUCER_GROUP, "shenyu-plugin-logging-rocketmq");

--- a/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/RocketMqPluginTest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/RocketMqPluginTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.integrated.test.http.combination;
+
+import org.apache.shenyu.common.dto.PluginData;
+import org.apache.shenyu.common.enums.PluginEnum;
+import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.shenyu.integratedtest.common.AbstractPluginDataInit;
+import org.apache.shenyu.plugin.logging.common.entity.ShenyuRequestLog;
+import org.apache.shenyu.plugin.logging.rocketmq.config.LogCollectConfig;
+import org.apache.shenyu.plugin.logging.rocketmq.client.RocketMQLogCollectClient;
+import org.apache.shenyu.plugin.logging.rocketmq.constant.LoggingConstant;
+import org.apache.shenyu.plugin.logging.rocketmq.utils.RocketLogCollectConfigUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public final class RocketMqPluginTest extends AbstractPluginDataInit {
+
+    private final RocketMQLogCollectClient rocketMQLogCollectClient = new RocketMQLogCollectClient();
+
+    private final PluginData pluginData = new PluginData();
+
+    private final Properties properties = new Properties();
+
+    private final List<ShenyuRequestLog> logs = new ArrayList<>();
+
+    private final ShenyuRequestLog shenyuRequestLog = new ShenyuRequestLog();
+
+    @BeforeEach
+    public void setup() throws IOException {
+        String pluginResult = initPlugin(PluginEnum.LOGGING_ROCKETMQ.getName(),
+                "{\"topic\":\"rocket-mq-test\", \"namesrvAddr\":\"shenyu-rocketmq:9876\", \"producerGroup\":\"shenyu-plugin-logging-rocketmq\"}");
+        assertThat(pluginResult, is("success"));
+    }
+
+    @Test
+    public void testPass() {
+        LogCollectConfig.GlobalLogConfig globalLogConfig = GsonUtils.getInstance().fromJson(pluginData.getConfig(), LogCollectConfig.GlobalLogConfig.class);
+        properties.setProperty(LoggingConstant.TOPIC, "shenyu-access-logging");
+        properties.setProperty(LoggingConstant.NAMESERVER_ADDRESS, "shenyu-rocketmq:9876");
+        properties.setProperty(LoggingConstant.PRODUCER_GROUP, "shenyu-plugin-logging-rocketmq");
+
+        shenyuRequestLog.setClientIp("0.0.0.0");
+        shenyuRequestLog.setPath("org/apache/shenyu/plugin/logging");
+        logs.add(shenyuRequestLog);
+
+        String msg = "";
+        RocketLogCollectConfigUtils.setGlobalConfig(globalLogConfig);
+        rocketMQLogCollectClient.initProducer(properties);
+        try {
+            rocketMQLogCollectClient.consume(logs);
+        } catch (Exception e) {
+            msg = "false";
+        }
+        Assertions.assertEquals(msg, "");
+        rocketMQLogCollectClient.close();
+    }
+
+}

--- a/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/RocketMqPluginTest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/RocketMqPluginTest.java
@@ -26,6 +26,7 @@ import org.apache.shenyu.plugin.logging.rocketmq.config.LogCollectConfig;
 import org.apache.shenyu.plugin.logging.rocketmq.client.RocketMQLogCollectClient;
 import org.apache.shenyu.plugin.logging.rocketmq.constant.LoggingConstant;
 import org.apache.shenyu.plugin.logging.rocketmq.utils.RocketLogCollectConfigUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,4 +81,8 @@ public final class RocketMqPluginTest extends AbstractPluginDataInit {
         rocketMQLogCollectClient.close();
     }
 
+    @AfterAll
+    public static void clean() throws IOException {
+        cleanPluginData(PluginEnum.LOGGING_ROCKETMQ.getName());
+    }
 }


### PR DESCRIPTION
This pr is used to test whether rocketmq is integrated into shenyu.
The test case steps are as follows:
1. Add a message to rocketmq
2. Consume this information

If the consumption is successful, it means that rocketmq is integrated into shenyu. If the consumption fails, an exception will be thrown, indicating that there is a problem with rocketmq.