### PR TITLE
[type:fixbug] fix exchange NPE and file cannot open

### DIFF
--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
@@ -54,14 +54,13 @@ public class WebClientPlugin extends AbstractHttpClientPlugin<ClientResponse> {
         // springWebflux5.3 mark #exchange() deprecated. because #echange maybe make memory leak.
         // https://github.com/spring-projects/spring-framework/issues/25751
         // exchange is deprecated, so change to {@link WebClient.RequestHeadersSpec#exchangeToMono(Function)}
+        // exchangeToMono have two important bug:
+        // 1.exchangeToMono can cause NPE when response body is null
+        // 2.download file with exchangeToMono can't open
         return webClient.method(HttpMethod.valueOf(httpMethod)).uri(uri)
                 .headers(headers -> headers.addAll(httpHeaders))
                 .body(BodyInserters.fromDataBuffers(body))
-                .exchangeToMono(res -> res.bodyToMono(String.class)
-                        .map(responseBody -> ClientResponse.create(res.statusCode())
-                                .headers(headers -> headers.addAll(res.headers().asHttpHeaders()))
-                                .body(responseBody)
-                                .build()))
+                .exchange()
                 .doOnSuccess(res -> {
                     if (res.statusCode().is2xxSuccessful()) {
                         exchange.getAttributes().put(Constants.CLIENT_RESPONSE_RESULT_TYPE, ResultEnum.SUCCESS.getName());

--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
@@ -48,7 +48,6 @@ public class WebClientPlugin extends AbstractHttpClientPlugin<ClientResponse> {
         this.webClient = webClient;
     }
 
-    @D
     @Override
     protected Mono<ClientResponse> doRequest(final ServerWebExchange exchange, final String httpMethod, final URI uri,
                                              final HttpHeaders httpHeaders, final Flux<DataBuffer> body) {

--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
@@ -48,13 +48,14 @@ public class WebClientPlugin extends AbstractHttpClientPlugin<ClientResponse> {
         this.webClient = webClient;
     }
 
+    @D
     @Override
     protected Mono<ClientResponse> doRequest(final ServerWebExchange exchange, final String httpMethod, final URI uri,
                                              final HttpHeaders httpHeaders, final Flux<DataBuffer> body) {
         // springWebflux5.3 mark #exchange() deprecated. because #echange maybe make memory leak.
         // https://github.com/spring-projects/spring-framework/issues/25751
         // exchange is deprecated, so change to {@link WebClient.RequestHeadersSpec#exchangeToMono(Function)}
-        // exchangeToMono have two important bug:
+        // exchangeToMono has two important bug:
         // 1.exchangeToMono can cause NPE when response body is null
         // 2.download file with exchangeToMono can't open
         return webClient.method(HttpMethod.valueOf(httpMethod)).uri(uri)

--- a/shenyu-plugin/shenyu-plugin-modify-response/src/main/java/org/apache/shenyu/plugin/modify/response/ModifyResponsePlugin.java
+++ b/shenyu-plugin/shenyu-plugin-modify-response/src/main/java/org/apache/shenyu/plugin/modify/response/ModifyResponsePlugin.java
@@ -147,6 +147,7 @@ public class ModifyResponsePlugin extends AbstractShenyuPlugin {
             return ClientResponse.create(statusCode)
                     .rawStatusCode(rowStatusCode)
                     .headers(headers -> headers.addAll(httpHeaders))
+                    .cookies(cookies -> cookies.addAll(this.getCookies()))
                     .body(Flux.from(body)).build();
         }
 


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

Fixes #3686 and #3687 

through exchange is deprecated, this can use normally and can't NPE and cause file can't open.

ExchangeToMono has two questions: #3686 and #3687

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
