### PR TITLE
[type:bug] Fix Shenyu plugin logging aliyun SLS duplicate declaration org.springframework: spring-test

### DIFF
--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/pom.xml
@@ -55,12 +55,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Fix Shenyu plugin logging aliyun SLS duplicate declaration org.springframework: spring-test.

Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
