### PR TITLE
[type:bug] fix not find license-header path in child module.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -615,6 +615,7 @@
                 <version>${maven-checkstyle-plugin.version}</version>
                 <configuration>
                     <configLocation>/script/shenyu_checkstyle.xml</configLocation>
+                    <headerLocation>/script/checkstyle-header.txt</headerLocation>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <excludes>**/transfer/**/*</excludes>
                 </configuration>

--- a/script/shenyu_checkstyle.xml
+++ b/script/shenyu_checkstyle.xml
@@ -22,7 +22,7 @@
     <property name="severity" value="error"/>
     <property name="fileExtensions" value="java, properties, xml"/>
     <module name="Header">
-        <property name="headerFile" value="./script/checkstyle-header.txt"/>
+        <property name="headerFile" value="${checkstyle.header.file}"/>
         <property name="fileExtensions" value="java"/>
     </module>
     <module name="FileTabCharacter">


### PR DESCRIPTION
task1 also. [#3697](https://github.com/apache/incubator-shenyu/issues/3697)

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
